### PR TITLE
bugfix: Descriptions for datasets and spaces (closes #25)

### DIFF
--- a/hf_repo_exporter.py
+++ b/hf_repo_exporter.py
@@ -296,7 +296,7 @@ def get_repo_info(api, repo, repo_type: str) -> dict[str, str | int]:
     return {
         "Repository Name": f'=HYPERLINK("{get_repo_url(repo, repo_type)}", "{display_id}")',
         "Repository Type": repo_type,
-        "Description": get_model_card_field(repo, ["model_description", "description"]) or "N/A",
+        "Description": get_card_field(repo, ["model_description", "description"]) or "N/A",
         "Date Created": repo.created_at.strftime("%Y-%m-%d") if getattr(repo, "created_at", False) else "N/A",
         "Last Updated": repo.lastModified.strftime("%Y-%m-%d") if getattr(repo, "lastModified", False) else "N/A",
         "Created By": get_author(api, repo.id, repo_type),

--- a/hf_repo_exporter.py
+++ b/hf_repo_exporter.py
@@ -141,16 +141,18 @@ def is_inactive(repo) -> str:
     except Exception:
         return "N/A"
 
-def get_model_card_field(repo, key: str) -> str:
+def get_model_card_field(repo, keys: list) -> str:
     try:
-        value = repo.card_data.get(key, "")
-        # Convert to string if it's a list or other type
-        if isinstance(value, list):
-            return ", ".join(str(v) for v in value)
-        return str(value) if value else ""
+        for key in keys:
+            value = repo.card_data.get(key, "")
+            if value:
+                # Convert to string if it's a list or other type
+                if isinstance(value, list):
+                    return ", ".join(str(v) for v in value)
+                return str(value) if value else ""
     except Exception:
-        return "N/A"
-    
+        pass
+    return "N/A"
 def get_associated_datasets(repo) -> str:
     try:
         # Looking for tags like 'dataset:user/repo'
@@ -294,7 +296,7 @@ def get_repo_info(api, repo, repo_type: str) -> dict[str, str | int]:
     return {
         "Repository Name": f'=HYPERLINK("{get_repo_url(repo, repo_type)}", "{display_id}")',
         "Repository Type": repo_type,
-        "Description": get_model_card_field(repo, "model_description") or "N/A",
+        "Description": get_model_card_field(repo, ["model_description", "description"]) or "N/A",
         "Date Created": repo.created_at.strftime("%Y-%m-%d") if getattr(repo, "created_at", False) else "N/A",
         "Last Updated": repo.lastModified.strftime("%Y-%m-%d") if getattr(repo, "lastModified", False) else "N/A",
         "Created By": get_author(api, repo.id, repo_type),

--- a/hf_repo_exporter.py
+++ b/hf_repo_exporter.py
@@ -152,6 +152,7 @@ def get_card_field(repo, keys: list) -> str:
                 return str(value) if value else ""
     except Exception:
         return "N/A"
+    
 def get_associated_datasets(repo) -> str:
     try:
         # Looking for tags like 'dataset:user/repo'

--- a/hf_repo_exporter.py
+++ b/hf_repo_exporter.py
@@ -141,7 +141,7 @@ def is_inactive(repo) -> str:
     except Exception:
         return "N/A"
 
-def get_model_card_field(repo, keys: list) -> str:
+def get_card_field(repo, keys: list) -> str:
     try:
         for key in keys:
             value = repo.card_data.get(key, "")

--- a/hf_repo_exporter.py
+++ b/hf_repo_exporter.py
@@ -151,8 +151,7 @@ def get_card_field(repo, keys: list) -> str:
                     return ", ".join(str(v) for v in value)
                 return str(value) if value else ""
     except Exception:
-        pass
-    return "N/A"
+        return "N/A"
 def get_associated_datasets(repo) -> str:
     try:
         # Looking for tags like 'dataset:user/repo'


### PR DESCRIPTION
### Problem
The repository exporter was only populating the Description column for Model repositories. This occurred because the script was hardcoded to look specifically for the `model_description` key in the Hugging Face YAML metadata. Since Datasets and Spaces use different metadata keys (`description`), these columns remained as "N/A" or empty in the generated spreadsheet.

### Solution
I have updated the metadata extraction logic to include the added key:

* **Multi-Key Search:** Modified `get_model_card_field` to accept a list of potential keys, checking for model_description and description.

---
**Closes #25**