### PR TITLE
Issue#38 fix by replacing get_repo_creator to use repo.owner instead of commit history

### DIFF
--- a/gh_repo_exporter.py
+++ b/gh_repo_exporter.py
@@ -47,10 +47,8 @@ def get_num_branches(repo) -> int | str:
     
 def get_repo_creator(repo) -> str:
     try:
-        commits = repo.get_commits()
-        first_commit = commits.reversed[0]
-        author = first_commit.author
-        return f"{author.name} ({author.login})" if author else "N/A"
+        owner = repo.owner
+        return f"{owner.name} ({owner.login})" if owner else "N/A"
     except Exception:
         return "N/A"
     


### PR DESCRIPTION
#38

`get_repo_creator` before was fetching the repo creator by going through 
the entire commit history to find the very first commit, which was extremely 
slow for repos with a large number of commits.

This fix replaces that approach by using repo.owner instead so that it directly 
asks GitHub who owns or created the repo without needing to touch commit history. This is faster and more accurate since it reflects who actually created the repo on GitHub rather than who made the first commit, which aren't always the same person.