### PR TITLE
Fix package requirements check to include R and JS/HTML files

### DIFF
--- a/gh_repo_exporter.py
+++ b/gh_repo_exporter.py
@@ -270,7 +270,15 @@ def get_repo_info(repo) -> dict[str, str | int]:
         "README": has_readme(repo),
         "License": has_license(repo),
         ".gitignore": has_file(repo, ".gitignore"),
-        "Package Requirements": has_file(repo, "requirements.txt", "environment.yaml", "environment.yml", "pyproject.toml"),
+        "Package Requirements": has_file(
+            repo, 
+            # Python
+            "requirements.txt", "environment.yaml", "environment.yml", "pyproject.toml",
+            # R
+            "DESCRIPTION", "renv.lock", "packrat/packrat.lock",
+            # JavaScript / HTML
+            "package.json", "package-lock.json", "yarn.lock", "bower.json",
+            ),
         "CITATION": has_file(repo, "CITATION.cff"),
         ".zenodo.json": has_file(repo, ".zenodo.json"),
         "CONTRIBUTING": has_file(repo, "CONTRIBUTING.md"),

--- a/gh_repo_exporter.py
+++ b/gh_repo_exporter.py
@@ -15,6 +15,16 @@ ORG_NAME = "Imageomics"
 SPREADSHEET_ID = "15BQimTjaOyo-jeaJRcg1Hia-9ORcilj3Jx-ks-uGyoc"
 SHEET_NAME = "Sheet1"
 
+# Package requirement files to check
+PACKAGE_REQUIREMENT_FILES = [
+    # Python 
+    "requirements.txt", "environment.yaml", "environment.yml", "pyproject.toml",
+    # R
+    "DESCRIPTION", "renv.lock", "packrat/packrat.lock",
+    # JavaScript / HTML
+    "package.json", "package-lock.json", "yarn.lock", "bower.json",
+]
+
 # Helper Functions
 def has_file(repo, *paths: str) -> str:
     for path in paths:
@@ -270,15 +280,7 @@ def get_repo_info(repo) -> dict[str, str | int]:
         "README": has_readme(repo),
         "License": has_license(repo),
         ".gitignore": has_file(repo, ".gitignore"),
-        "Package Requirements": has_file(
-            repo, 
-            # Python
-            "requirements.txt", "environment.yaml", "environment.yml", "pyproject.toml",
-            # R
-            "DESCRIPTION", "renv.lock", "packrat/packrat.lock",
-            # JavaScript / HTML
-            "package.json", "package-lock.json", "yarn.lock", "bower.json",
-            ),
+        "Package Requirements": has_file(repo, *PACKAGE_REQUIREMENT_FILES),
         "CITATION": has_file(repo, "CITATION.cff"),
         ".zenodo.json": has_file(repo, ".zenodo.json"),
         "CONTRIBUTING": has_file(repo, "CONTRIBUTING.md"),


### PR DESCRIPTION
#30

The `has_file()` call for "Package Requirements" in `get_repo_info()` before only checked for Python dependency files and it needs to include other languages as well. I updated to also check for R and JavaScript/HTML files.