### PR TITLE
Add reuse of existing sheet data to avoid recomputing repository creator

### DIFF
--- a/gh_repo_exporter.py
+++ b/gh_repo_exporter.py
@@ -55,13 +55,30 @@ def get_num_branches(repo) -> int | str:
     except:
         return "N/A"
     
-def get_repo_creator(repo) -> str:
+def get_repo_creator(repo, existing_df: pd.DataFrame = None) -> str:
     try:
+        
+         # Check if repo already exists in sheet. If so, reuse existing value instead of slow search
+        if existing_df is not None and not existing_df.empty:
+            repo_name = repo.name
+            date_created = repo.created_at.strftime("%Y-%m-%d")
+            match = existing_df[
+                (existing_df["Repository Name"] == repo_name) &
+                (existing_df["Date Created"] == date_created)
+            ]
+            if not match.empty:
+                existing_creator = match.iloc[0]["Created By"]
+                if existing_creator and existing_creator != "N/A":
+                    return existing_creator
+        
+        # Repo not found in sheet, fetch creator from commit history      
         commits = repo.get_commits()
         first_commit = commits.reversed[0]
         author = first_commit.author
         return f"{author.name} ({author.login})" if author else "N/A"
-    except Exception:
+    
+    except Exception as e:
+        print(f"Warning: Could not determine creator for {repo.name}: {e}")
         return "N/A"
     
 def get_top_contributors(repo, top_n: int = 4) -> str:
@@ -270,7 +287,7 @@ def get_associated_paper(readme: str, homepage: str | None = None) -> str:
         return "No"
     
     
-def get_repo_info(repo) -> dict[str, str | int]:
+def get_repo_info(repo, existing_df: pd.DataFrame = None) -> dict[str, str | int]:
     try:
         readme_content_lower = repo.get_readme().decoded_content.decode("utf-8", errors="ignore").lower()
     except Exception:
@@ -281,7 +298,7 @@ def get_repo_info(repo) -> dict[str, str | int]:
         "Description": repo.description or "N/A",
         "Date Created": repo.created_at.strftime("%Y-%m-%d"),
         "Last Updated": repo.updated_at.strftime("%Y-%m-%d"),
-        "Created By": get_repo_creator(repo),
+        "Created By": get_repo_creator(repo, existing_df),
         "Top 4 Contributors (lines of code changes)": get_top_contributors(repo, 4),
         "Stars": repo.stargazers_count,
         "# of Branches": get_num_branches(repo),
@@ -460,6 +477,43 @@ def main():
     REPO_TYPE = os.getenv("REPO_TYPE")
     repos = list(org.get_repos(type=REPO_TYPE))
     data = []
+    
+    # Load repo name, date created, and created by columns from existing sheet before fetching repo 
+    # to avoid recomputing "Created By" for repos already in the sheet
+    
+    existing_df = pd.DataFrame()
+
+    try:
+        creds_path = os.getenv("GOOGLE_CREDENTIALS_PATH", "service_account.json")
+
+        creds = Credentials.from_service_account_file(
+            creds_path,
+            scopes=[
+                "https://www.googleapis.com/auth/spreadsheets",
+                "https://www.googleapis.com/auth/drive"
+            ]
+        )
+
+        client = gspread.authorize(creds)
+        sheet = client.open_by_key(SPREADSHEET_ID).worksheet(SHEET_NAME)
+
+        all_values = sheet.get_all_values()
+
+        if len(all_values) > 2:
+            headers = all_values[1]
+            rows = all_values[2:]
+
+            full_df = pd.DataFrame(rows, columns=headers)
+
+            existing_df = full_df[
+                ["Repository Name", "Date Created", "Created By"]
+            ]
+            
+            existing_df["Repository Name"] = (existing_df["Repository Name"].apply(extract_display_name)
+            )
+
+    except Exception as e:
+        print(f"Warning: Could not load existing sheet data: {e}")
 
     tqdm_kwargs = {}
     if os.environ.get("CI") == "true":
@@ -467,7 +521,7 @@ def main():
 
     for repo in tqdm(repos, desc=f"Fetching repositories from {ORG_NAME}...", unit="repo", colour="green", ncols=100, **tqdm_kwargs):
         try:
-            info = get_repo_info(repo)
+            info = get_repo_info(repo, existing_df)
             data.append(info)
             tqdm.write(f"Fetched info for /{repo.name} repo")
         except Exception as e:

--- a/gh_repo_exporter.py
+++ b/gh_repo_exporter.py
@@ -73,10 +73,18 @@ def get_repo_creator(repo, existing_df: pd.DataFrame = None) -> str:
                     if existing_creator and existing_creator != "N/A":
                         return existing_creator
         
-        # Repo not found in sheet, fetch creator from commit history      
+        # Repo not found in sheet, fetch creator from commit history
         commits = repo.get_commits()
-        first_commit = commits.reversed[0]
-        author = first_commit.author
+        total = commits.totalCount
+        if not total:
+            return "N/A"
+
+        # Avoid loading the entire history into memory: fetch only the last page.
+        per_page = getattr(getattr(repo, "_requester", None), "per_page", 30) or 30
+        last_page = (total - 1) // per_page
+        oldest_page = commits.get_page(last_page)
+        oldest_commit = oldest_page[-1] if oldest_page else None
+        author = oldest_commit.author if oldest_commit else None
         return f"{author.name} ({author.login})" if author else "N/A"
     
     except Exception as e:
@@ -548,11 +556,9 @@ def main():
 
             full_df = pd.DataFrame(rows, columns=headers)
 
-            existing_df = full_df[
-                ["Repository Name", "Date Created", "Created By"]
-            ].copy()
-            
-            existing_df["Repository Name"] = existing_df["Repository Name"].apply(extract_display_name)
+            existing_df["Repository Name"] = existing_df["Repository Name"].apply(
+                lambda v: extract_display_name(v) if isinstance(v, str) else ""
+            )
 
     except Exception as e:
         print(f"Warning: Could not load existing sheet data: {e}")

--- a/gh_repo_exporter.py
+++ b/gh_repo_exporter.py
@@ -378,7 +378,27 @@ def get_associated_paper(readme: str, homepage: str | None = None) -> str:
     except Exception:
         return "No"
     
-    
+def get_website_reference(homepage: str | None) -> str:
+    try:
+        if not homepage:
+            return "No"
+        
+        # Return "No" if homepage is a paper, dataset, or model link instead of an actual website
+        external_patterns = [
+            "arxiv.org",
+            "huggingface.co",
+            "hf.co",
+            "doi.org",
+        ]
+        
+        if any(pattern in homepage.lower() for pattern in external_patterns):
+            return "No"
+        
+        cleaned = homepage.rstrip(").],};:>\"'")
+        return f'=HYPERLINK("{cleaned}", "Yes")'
+    except Exception:
+        return "No"
+     
 def get_repo_info(repo, existing_df: pd.DataFrame = None) -> dict[str, str | int]:
     try:
         readme_content_lower = repo.get_readme().decoded_content.decode("utf-8", errors="ignore").lower()
@@ -406,7 +426,7 @@ def get_repo_info(repo, existing_df: pd.DataFrame = None) -> dict[str, str | int
         "Visibility": "Private" if repo.private else "Public",
         "Forks": "Yes" if repo.fork else "No",
         "Inactive": is_inactive(repo),
-        "Website Reference": f'=HYPERLINK("{repo.homepage}", "Yes")' if repo.homepage else "No",
+        "Website Reference": get_website_reference(repo.homepage),
         "Dataset": get_dataset(readme_content_lower, repo.name.lower()),
         "Model": get_model(readme_content_lower),
         "Paper Association": get_associated_paper(readme_content_lower, repo.homepage),

--- a/gh_repo_exporter.py
+++ b/gh_repo_exporter.py
@@ -63,8 +63,10 @@ def get_repo_creator(repo, existing_df: pd.DataFrame = None) -> str:
             repo_name = repo.name
             date_created = repo.created_at.strftime("%Y-%m-%d")
             match = existing_df.loc[
+            match = existing_df.loc[
                 (existing_df["Repository Name"] == repo_name) &
                 (existing_df["Date Created"] == date_created)
+            ].copy()
             ].copy()
             if not match.empty:
                 existing_creator = match.iloc[0]["Created By"]
@@ -476,6 +478,7 @@ def main():
 
     REPO_TYPE = os.getenv("REPO_TYPE")
     repos = list(org.get_repos(type=REPO_TYPE))
+    print(f"Total repos fetched: {len(repos)}")
     data = []
     
     # Load repo name, date created, and created by columns from existing sheet before fetching repo 
@@ -507,6 +510,7 @@ def main():
 
             existing_df = full_df[
                 ["Repository Name", "Date Created", "Created By"]
+            ].copy()
             ].copy()
             
             existing_df["Repository Name"] = existing_df["Repository Name"].apply(extract_display_name)

--- a/gh_repo_exporter.py
+++ b/gh_repo_exporter.py
@@ -507,7 +507,7 @@ def main():
 
             existing_df = full_df[
                 ["Repository Name", "Date Created", "Created By"]
-            ]
+            ].copy()
             
             existing_df["Repository Name"] = (existing_df["Repository Name"].apply(extract_display_name)
             )

--- a/gh_repo_exporter.py
+++ b/gh_repo_exporter.py
@@ -509,8 +509,7 @@ def main():
                 ["Repository Name", "Date Created", "Created By"]
             ].copy()
             
-            existing_df["Repository Name"] = (existing_df["Repository Name"].apply(extract_display_name)
-            )
+            existing_df["Repository Name"] = existing_df["Repository Name"].apply(extract_display_name)
 
     except Exception as e:
         print(f"Warning: Could not load existing sheet data: {e}")

--- a/gh_repo_exporter.py
+++ b/gh_repo_exporter.py
@@ -63,10 +63,8 @@ def get_repo_creator(repo, existing_df: pd.DataFrame = None) -> str:
             repo_name = repo.name
             date_created = repo.created_at.strftime("%Y-%m-%d")
             match = existing_df.loc[
-            match = existing_df.loc[
                 (existing_df["Repository Name"] == repo_name) &
                 (existing_df["Date Created"] == date_created)
-            ].copy()
             ].copy()
             if not match.empty:
                 existing_creator = match.iloc[0]["Created By"]
@@ -510,7 +508,6 @@ def main():
 
             existing_df = full_df[
                 ["Repository Name", "Date Created", "Created By"]
-            ].copy()
             ].copy()
             
             existing_df["Repository Name"] = existing_df["Repository Name"].apply(extract_display_name)

--- a/gh_repo_exporter.py
+++ b/gh_repo_exporter.py
@@ -62,10 +62,10 @@ def get_repo_creator(repo, existing_df: pd.DataFrame = None) -> str:
         if existing_df is not None and not existing_df.empty:
             repo_name = repo.name
             date_created = repo.created_at.strftime("%Y-%m-%d")
-            match = existing_df[
+            match = existing_df.loc[
                 (existing_df["Repository Name"] == repo_name) &
                 (existing_df["Date Created"] == date_created)
-            ]
+            ].copy()
             if not match.empty:
                 existing_creator = match.iloc[0]["Created By"]
                 if existing_creator and existing_creator != "N/A":

--- a/gh_repo_exporter.py
+++ b/gh_repo_exporter.py
@@ -83,28 +83,17 @@ def get_repo_creator(repo, existing_df: pd.DataFrame = None) -> str:
     
 def get_top_contributors(repo, top_n: int = 4) -> str:
     try:
-        # Keep repeatedly fetching stats since it may take time for GitHub to fetch that data
-        stats = None
-        for _ in range(3):
-            stats = repo.get_stats_contributors()
-            if stats:
+        # Fetch top 4 contributors sorted by commit count using get_contributors()
+        contributors = repo.get_contributors()
+        top_n_contributors = []
+
+        for i, contributor in enumerate(contributors):
+            if i >= top_n:
                 break
-            time.sleep(20)
-
-        if not stats:
-            return "N/A"
-        
-        contributors = []
-        for contributor in stats:
+            top_n_contributors.append(f"{contributor.name} ({contributor.login})")
             
-            total_additions = sum(week.a for week in contributor.weeks)
-            total_deletions = sum(week.d for week in contributor.weeks)
-            total_changes = total_additions + total_deletions
+        return ", ".join(top_n_contributors) if top_n_contributors else "N/A"
 
-            contributors.append((contributor.author.name, contributor.author.login, total_changes))
-
-        top_n_contributors = sorted(contributors, key=lambda x: x[2], reverse=True)[:top_n] # sort and take the top N results
-        return ", ".join([f"{name} ({login})" for name, login, _ in top_n_contributors])
     except Exception:
         return "N/A"
     
@@ -299,7 +288,7 @@ def get_repo_info(repo, existing_df: pd.DataFrame = None) -> dict[str, str | int
         "Date Created": repo.created_at.strftime("%Y-%m-%d"),
         "Last Updated": repo.updated_at.strftime("%Y-%m-%d"),
         "Created By": get_repo_creator(repo, existing_df),
-        "Top 4 Contributors (lines of code changes)": get_top_contributors(repo, 4),
+        "Top 4 Contributors (commits)": get_top_contributors(repo, 4),
         "Stars": repo.stargazers_count,
         "# of Branches": get_num_branches(repo),
         "README": has_readme(repo),
@@ -490,8 +479,8 @@ def main():
         creds = Credentials.from_service_account_file(
             creds_path,
             scopes=[
-                "https://www.googleapis.com/auth/spreadsheets",
-                "https://www.googleapis.com/auth/drive"
+               "https://www.googleapis.com/auth/spreadsheets",
+               "https://www.googleapis.com/auth/drive"
             ]
         )
 
@@ -519,6 +508,8 @@ def main():
     if os.environ.get("CI") == "true":
         tqdm_kwargs = {"mininterval": 1, "dynamic_ncols": False, "leave": False}
 
+    print(f"Existing sheet data shape: {existing_df.shape}")
+    
     for repo in tqdm(repos, desc=f"Fetching repositories from {ORG_NAME}...", unit="repo", colour="green", ncols=100, **tqdm_kwargs):
         try:
             info = get_repo_info(repo, existing_df)

--- a/gh_repo_exporter.py
+++ b/gh_repo_exporter.py
@@ -59,7 +59,11 @@ def get_repo_creator(repo, existing_df: pd.DataFrame = None) -> str:
     try:
         
          # Check if repo already exists in sheet. If so, reuse existing value instead of slow search
-        if existing_df is not None and not existing_df.empty:
+        if (
+            existing_df is not None
+            and not existing_df.empty
+            and {"Repository Name", "Date Created", "Created By"}.issubset(existing_df.columns)
+            ):
             repo_name = repo.name
             date_created = repo.created_at.strftime("%Y-%m-%d")
             match = existing_df.loc[
@@ -88,7 +92,7 @@ def get_repo_creator(repo, existing_df: pd.DataFrame = None) -> str:
         return f"{author.name} ({author.login})" if author else "N/A"
     
     except Exception as e:
-        print(f"Warning: Could not determine creator for {repo.name}: {e}")
+        tqdm.write(f"Warning: Could not determine creator for {repo.name}: {e}")
         return "N/A"
 
 def get_top_contributors(repo, top_n: int = 4) -> str:

--- a/gh_repo_exporter.py
+++ b/gh_repo_exporter.py
@@ -9,6 +9,7 @@ from datetime import datetime, timedelta, timezone
 import time
 import os
 import re
+import requests
 
 # Config
 ORG_NAME = "Imageomics"
@@ -80,22 +81,124 @@ def get_repo_creator(repo, existing_df: pd.DataFrame = None) -> str:
     except Exception as e:
         print(f"Warning: Could not determine creator for {repo.name}: {e}")
         return "N/A"
-    
-def get_top_contributors(repo, top_n: int = 4) -> str:
+  
+def get_top_contributors_graphql(repo_full_name: str, top_n: int = 4) -> str:
+    # Fallback method using GraphQL API to get top contributors by lines of code changes 
     try:
-        # Fetch top 4 contributors sorted by commit count using get_contributors()
-        contributors = repo.get_contributors()
-        top_n_contributors = []
+        token = os.getenv("GH_TOKEN")
+        if not token:
+            return "N/A"
+        
+        contributors = {}
+        cursor = None
+        headers = {
+            "Authorization": f"bearer {token}",
+            "Content-Type": "application/json"
+        }
+        owner, repo_name = repo_full_name.split("/")
 
-        for i, contributor in enumerate(contributors):
-            if i >= top_n:
+        while True:
+            after = f', after: "{cursor}"' if cursor else ""
+            query = f"""
+            {{
+              repository(owner: "{owner}", name: "{repo_name}") {{
+                defaultBranchRef {{
+                  target {{
+                    ... on Commit {{
+                      history(first: 100{after}) {{
+                        pageInfo {{
+                          hasNextPage
+                          endCursor
+                        }}
+                        nodes {{
+                          additions
+                          deletions
+                          author {{
+                            name
+                            user {{
+                              login
+                            }}
+                          }}
+                        }}
+                      }}
+                    }}
+                  }}
+                }}
+              }}
+            }}
+            """
+
+            response = requests.post(
+                "https://api.github.com/graphql",
+                json={"query": query},
+                headers=headers
+            )
+
+            data = response.json()
+
+            if "errors" in data:
+                return "N/A"
+
+            repository = data["data"]["repository"]
+            if not repository:
+                return "N/A"
+
+            default_branch = repository["defaultBranchRef"]
+            if not default_branch:
+                return "N/A"
+
+            history = default_branch["target"]["history"]
+
+            for commit in history["nodes"]:
+                author = commit["author"]
+                if author and author["user"]:
+                    name = author["user"]["login"]
+                else:
+                    name = author["name"] or "Unknown"
+
+                changes = (commit["additions"] or 0) + (commit["deletions"] or 0)
+                contributors[name] = contributors.get(name, 0) + changes
+
+            if not history["pageInfo"]["hasNextPage"]:
                 break
-            top_n_contributors.append(f"{contributor.name} ({contributor.login})")
-            
-        return ", ".join(top_n_contributors) if top_n_contributors else "N/A"
+
+            cursor = history["pageInfo"]["endCursor"]
+
+        sorted_contributors = sorted(contributors.items(), key=lambda x: x[1], reverse=True)
+        return ", ".join([name for name, _ in sorted_contributors[:top_n]]) or "N/A"
 
     except Exception:
         return "N/A"
+
+def get_top_contributors(repo, top_n: int = 4) -> str:
+    try:
+        # Primary approach using get_stats_contributors() for lines of code ranking
+        stats = None
+        for _ in range(3):
+            stats = repo.get_stats_contributors()
+            if stats:
+                break
+            time.sleep(20)
+
+        if not stats:
+            # Fallback: use GraphQL API if get_stats_contributors() fails
+            tqdm.write(f"  Falling back to GraphQL for {repo.name}...")
+            return get_top_contributors_graphql(repo.full_name, top_n)
+
+        contributors = []
+        for contributor in stats:
+            total_additions = sum(week.a for week in contributor.weeks)
+            total_deletions = sum(week.d for week in contributor.weeks)
+            total_changes = total_additions + total_deletions
+            contributors.append((contributor.author.name, contributor.author.login, total_changes))
+
+        top_n_contributors = sorted(contributors, key=lambda x: x[2], reverse=True)[:top_n]
+        return ", ".join([f"{name} ({login})" for name, login, _ in top_n_contributors])
+
+    except Exception:
+        # Fallback: use GraphQL API if get_stats_contributors() raises an exception
+        tqdm.write(f"  Falling back to GraphQL for {repo.name}...")
+        return get_top_contributors_graphql(repo.full_name, top_n)
     
 def is_inactive(repo) -> str:
     try:
@@ -288,7 +391,7 @@ def get_repo_info(repo, existing_df: pd.DataFrame = None) -> dict[str, str | int
         "Date Created": repo.created_at.strftime("%Y-%m-%d"),
         "Last Updated": repo.updated_at.strftime("%Y-%m-%d"),
         "Created By": get_repo_creator(repo, existing_df),
-        "Top 4 Contributors (commits)": get_top_contributors(repo, 4),
+        "Top 4 Contributors (lines of code changes)": get_top_contributors(repo, 4),
         "Stars": repo.stargazers_count,
         "# of Branches": get_num_branches(repo),
         "README": has_readme(repo),

--- a/gh_repo_exporter.py
+++ b/gh_repo_exporter.py
@@ -67,9 +67,11 @@ def get_repo_creator(repo, existing_df: pd.DataFrame = None) -> str:
                 (existing_df["Date Created"] == date_created)
             ].copy()
             if not match.empty:
-                existing_creator = match.iloc[0]["Created By"]
-                if existing_creator and existing_creator != "N/A":
-                    return existing_creator
+                existing_creator = match.iloc[0].get("Created By")
+                if isinstance(existing_creator, str):
+                    existing_creator = existing_creator.strip()
+                    if existing_creator and existing_creator != "N/A":
+                        return existing_creator
         
         # Repo not found in sheet, fetch creator from commit history      
         commits = repo.get_commits()

--- a/gh_repo_exporter.py
+++ b/gh_repo_exporter.py
@@ -9,7 +9,6 @@ from datetime import datetime, timedelta, timezone
 import time
 import os
 import re
-import requests
 
 # Config
 ORG_NAME = "Imageomics"
@@ -81,94 +80,6 @@ def get_repo_creator(repo, existing_df: pd.DataFrame = None) -> str:
     except Exception as e:
         print(f"Warning: Could not determine creator for {repo.name}: {e}")
         return "N/A"
-  
-def get_top_contributors_graphql(repo_full_name: str, top_n: int = 4) -> str:
-    # Fallback method using GraphQL API to get top contributors by lines of code changes 
-    try:
-        token = os.getenv("GH_TOKEN")
-        if not token:
-            return "N/A"
-        
-        contributors = {}
-        cursor = None
-        headers = {
-            "Authorization": f"bearer {token}",
-            "Content-Type": "application/json"
-        }
-        owner, repo_name = repo_full_name.split("/")
-
-        while True:
-            after = f', after: "{cursor}"' if cursor else ""
-            query = f"""
-            {{
-              repository(owner: "{owner}", name: "{repo_name}") {{
-                defaultBranchRef {{
-                  target {{
-                    ... on Commit {{
-                      history(first: 100{after}) {{
-                        pageInfo {{
-                          hasNextPage
-                          endCursor
-                        }}
-                        nodes {{
-                          additions
-                          deletions
-                          author {{
-                            name
-                            user {{
-                              login
-                            }}
-                          }}
-                        }}
-                      }}
-                    }}
-                  }}
-                }}
-              }}
-            }}
-            """
-
-            response = requests.post(
-                "https://api.github.com/graphql",
-                json={"query": query},
-                headers=headers
-            )
-
-            data = response.json()
-
-            if "errors" in data:
-                return "N/A"
-
-            repository = data["data"]["repository"]
-            if not repository:
-                return "N/A"
-
-            default_branch = repository["defaultBranchRef"]
-            if not default_branch:
-                return "N/A"
-
-            history = default_branch["target"]["history"]
-
-            for commit in history["nodes"]:
-                author = commit["author"]
-                if author and author["user"]:
-                    name = author["user"]["login"]
-                else:
-                    name = author["name"] or "Unknown"
-
-                changes = (commit["additions"] or 0) + (commit["deletions"] or 0)
-                contributors[name] = contributors.get(name, 0) + changes
-
-            if not history["pageInfo"]["hasNextPage"]:
-                break
-
-            cursor = history["pageInfo"]["endCursor"]
-
-        sorted_contributors = sorted(contributors.items(), key=lambda x: x[1], reverse=True)
-        return ", ".join([name for name, _ in sorted_contributors[:top_n]]) or "N/A"
-
-    except Exception:
-        return "N/A"
 
 def get_top_contributors(repo, top_n: int = 4) -> str:
     try:
@@ -181,9 +92,9 @@ def get_top_contributors(repo, top_n: int = 4) -> str:
             time.sleep(20)
 
         if not stats:
-            # Fallback: use GraphQL API if get_stats_contributors() fails
-            tqdm.write(f"  Falling back to GraphQL for {repo.name}...")
-            return get_top_contributors_graphql(repo.full_name, top_n)
+            # Fallback: use commit-based approach if get_stats_contributors() fails
+            tqdm.write(f"  Falling back to commit-based for {repo.name}...")
+            return get_top_contributors_commits(repo, top_n)
 
         contributors = []
         for contributor in stats:
@@ -196,9 +107,26 @@ def get_top_contributors(repo, top_n: int = 4) -> str:
         return ", ".join([f"{name} ({login})" for name, login, _ in top_n_contributors])
 
     except Exception:
-        # Fallback: use GraphQL API if get_stats_contributors() raises an exception
-        tqdm.write(f"  Falling back to GraphQL for {repo.name}...")
-        return get_top_contributors_graphql(repo.full_name, top_n)
+        # Fallback: use commit-based approach if get_stats_contributors() raises an exception
+        tqdm.write(f"  Falling back to commit-based for {repo.name}...")
+        return get_top_contributors_commits(repo, top_n)
+
+def get_top_contributors_commits(repo, top_n: int = 4) -> str:
+    # Fallback method using commit count when get_stats_contributors() fails
+    try:
+        contributors = repo.get_contributors()
+        top_n_contributors = []
+
+        for i, contributor in enumerate(contributors):
+            if i >= top_n:
+                break
+            top_n_contributors.append(f"{contributor.name} ({contributor.login})")
+
+        result = ", ".join(top_n_contributors) if top_n_contributors else "N/A"
+        return f"{result} (commit-based)" if result != "N/A" else "N/A"
+
+    except Exception:
+        return "N/A"
     
 def is_inactive(repo) -> str:
     try:
@@ -364,7 +292,7 @@ def get_associated_paper(readme: str, homepage: str | None = None) -> str:
 
             # Check if URL matches a paper source
             for pattern in url_patterns:
-                if re.search(pattern, url):
+                if re.search(pattern, url, re.IGNORECASE):
                     cleaned = url.rstrip(").],};:>\"'")
                     return f'=HYPERLINK("{cleaned}", "Yes")'
                 

--- a/gh_repo_exporter.py
+++ b/gh_repo_exporter.py
@@ -555,7 +555,9 @@ def main():
             rows = all_values[2:]
 
             full_df = pd.DataFrame(rows, columns=headers)
-
+            existing_df = full_df[
+                    ["Repository Name", "Date Created", "Created By"]
+            ].copy()
             existing_df["Repository Name"] = existing_df["Repository Name"].apply(
                 lambda v: extract_display_name(v) if isinstance(v, str) else ""
             )

--- a/tests/test_repo_core.py
+++ b/tests/test_repo_core.py
@@ -1,297 +1,19 @@
 import unittest
-from unittest.mock import MagicMock, patch, PropertyMock
+from unittest.mock import MagicMock
 import pandas as pd
-import math
 
-from gh_repo_exporter import extract_display_name, get_repo_creator
-
-# --- Fix 1: safe lambda (main()) ---
-# The old code called .apply(extract_display_name) directly.
-# If a "Repository Name" cell is empty, pandas fills it with NaN (a float),
-# which causes extract_display_name to raise TypeError inside re.search().
-# Because that runs inside a broad try/except, one bad row silently empties
-# existing_df and disables the whole "skip already-fetched repos" optimization.
-# Fix: only call extract_display_name when the value is actually a string.
-
-def apply_extract_display_name_safe(series: pd.Series) -> pd.Series:
-    """Mirrors the fixed lambda: extract only if value is a str, else ''."""
-    return series.apply(
-        lambda v: extract_display_name(v) if isinstance(v, str) else ""
-    )
-
-# --- Fix 2: NaN-safe "Created By" lookup (get_repo_creator()) ---
-# The old code did match.iloc[0]["Created By"], which is NaN when the cell is
-# empty.  `if existing_creator` treats NaN as truthy (NaN != 0 in Python), so
-# the function returned a raw float NaN instead of falling back to commit history.
-# Fix: use .get() + isinstance guard so only real strings are returned.
-
-def _extract_creator_from_match(match_row) -> str | None:
-    """
-    Mirrors the fixed lines 70-74 in get_repo_creator.
-    Returns the creator string if valid, otherwise None (triggers fallback).
-    """
-    existing_creator = match_row.get("Created By")
-    if isinstance(existing_creator, str):
-        existing_creator = existing_creator.strip()
-        if existing_creator and existing_creator != "N/A":
-            return existing_creator
-    return None
-
-
-# --- Fix 3: paginated commit fallback (get_repo_creator()) ---
-# The old fallback used commits.reversed[0], which forces PyGitHub to traverse
-# the entire commit history — very slow for large repos (issue #38).
-# Fix: use totalCount + get_page(last_page) to jump straight to the oldest
-# page of commits with a single extra API call.
-
-def _get_creator_from_commits(repo) -> str:
-    """
-    Mirrors the fixed fallback block (lines 77-87).
-    Separated into its own function for unit-testability.
-    """
-    commits = repo.get_commits()
-    total = commits.totalCount
-    if not total:
-        return "N/A"
-
-    # Jump directly to the last page instead of reversing the whole history.
-    per_page = getattr(getattr(repo, "_requester", None), "per_page", 30) or 30
-    last_page = (total - 1) // per_page
-    oldest_page = commits.get_page(last_page)
-    oldest_commit = oldest_page[-1] if oldest_page else None
-    author = oldest_commit.author if oldest_commit else None
-
-    return f"{author.name} ({author.login})" if author else "N/A"
-
-# Tests
-
-class TestApplyExtractDisplayNameSafe(unittest.TestCase):
-    """
-    Covers the isinstance(v, str) guard added to the .apply() call in main().
-
-    Each test feeds a pandas Series into apply_extract_display_name_safe and
-    checks the output — no GitHub or Sheets API calls needed.
-    """
-
-    def test_normal_hyperlink_values_are_extracted(self):
-        # Happy path: well-formed HYPERLINK formulas should extract the repo name.
-        series = pd.Series([
-            '=HYPERLINK("https://github.com/org/repo-a", "repo-a")',
-            '=HYPERLINK("https://github.com/org/repo-b", "repo-b")',
-        ])
-        result = apply_extract_display_name_safe(series)
-        self.assertEqual(result[0], "repo-a")
-        self.assertEqual(result[1], "repo-b")
-
-    def test_nan_values_become_empty_string(self):
-        # Core bug: NaN must not raise TypeError; it should silently become ''.
-        series = pd.Series([
-            '=HYPERLINK("https://github.com/org/repo-a", "repo-a")',
-            float("nan"),
-        ])
-        result = apply_extract_display_name_safe(series)
-        self.assertEqual(result[0], "repo-a")
-        self.assertEqual(result[1], "")
-
-    def test_none_values_become_empty_string(self):
-        # None is also not a str, so it should fall through to "".
-        series = pd.Series([None, '=HYPERLINK("https://github.com/org/r", "r")'])
-        result = apply_extract_display_name_safe(series)
-        self.assertEqual(result[0], "")
-        self.assertEqual(result[1], "r")
-
-    def test_all_nan_series_returns_all_empty_strings(self):
-        # All-NaN series: every cell should become "" without raising.
-        series = pd.Series([float("nan"), float("nan")])
-        result = apply_extract_display_name_safe(series)
-        self.assertTrue((result == "").all())
-
-    def test_plain_string_without_hyperlink_syntax_returns_itself(self):
-        # If a cell holds a plain name (no HYPERLINK formula), the regex in extract_display_name finds no match and returns the original value.
-        series = pd.Series(["just-a-name"])
-        result = apply_extract_display_name_safe(series)
-        self.assertEqual(result[0], "just-a-name")
-
-
-class TestExtractCreatorFromMatch(unittest.TestCase):
-    """
-    Covers the isinstance + .strip() guard added to get_repo_creator() lines 70-74.
-
-    _make_row() builds a minimal pandas Series that mimics match.iloc[0] so
-    we can test the extraction logic without touching the GitHub API.
-    """
-
-    def _make_row(self, value):
-        """Return a pandas Series that mimics match.iloc[0]."""
-        return pd.Series({"Repository Name": "repo", "Date Created": "2024-01-01",
-                          "Created By": value})
-
-    def test_valid_creator_string_is_returned(self):
-        # Happy path: a clean "Name (login)" string comes back unchanged.
-        row = self._make_row("Alice (alice)")
-        self.assertEqual(_extract_creator_from_match(row), "Alice (alice)")
-
-    def test_creator_with_leading_trailing_whitespace_is_stripped(self):
-        # .strip() should remove surrounding whitespace before returning.
-        row = self._make_row("  Bob (bob)  ")
-        self.assertEqual(_extract_creator_from_match(row), "Bob (bob)")
-
-    def test_nan_creator_returns_none(self):
-        # Core bug: NaN is truthy in Python, so the old code returned raw NaN.The fix must return None so the caller falls back to commit history.
-        row = self._make_row(float("nan"))
-        self.assertIsNone(_extract_creator_from_match(row))
-
-    def test_na_string_returns_none(self):
-        # "N/A" means no creator was found previously; trigger fallback.
-        row = self._make_row("N/A")
-        self.assertIsNone(_extract_creator_from_match(row))
-
-    def test_empty_string_returns_none(self):
-        # Empty string is not a useful creator value; trigger fallback.
-        row = self._make_row("")
-        self.assertIsNone(_extract_creator_from_match(row))
-
-    def test_whitespace_only_string_returns_none(self):
-        # After .strip(), "   " becomes "" which is falsy and return None.
-        row = self._make_row("   ")
-        self.assertIsNone(_extract_creator_from_match(row))
-
-    def test_missing_key_returns_none(self):
-        # If the "Created By" column is absent entirely, .get() returns None (a dict/Series key miss), which is not a str — so we return None.
-        row = pd.Series({"Repository Name": "repo"})
-        self.assertIsNone(_extract_creator_from_match(row))
-
-
-class TestGetCreatorFromCommits(unittest.TestCase):
-    """
-    Covers the paginated commit fallback that replaces commits.reversed[0].
-
-    _make_repo() builds a MagicMock repo whose get_commits() return value is
-    pre-wired with a totalCount and a get_page() result, so no real API calls
-    are made.  We then assert on what _get_creator_from_commits returns AND
-    on which page index it actually requested.
-    """
-
-    def _make_repo(self, total_commits, per_page, oldest_author_name,
-                   oldest_author_login, oldest_page_commits=None):
-        """Build a minimal mock repo whose commit pagination is pre-configured."""
-        repo = MagicMock()
-        commits = MagicMock()
-        commits.totalCount = total_commits
-
-        if oldest_page_commits is None:
-            author = MagicMock()
-            author.name = oldest_author_name
-            author.login = oldest_author_login
-            last_commit = MagicMock()
-            last_commit.author = author
-            oldest_page_commits = [last_commit]
-
-        commits.get_page.return_value = oldest_page_commits
-
-        # Wire per_page onto _requester so the helper can read it.
-        requester = MagicMock()
-        requester.per_page = per_page
-        repo._requester = requester
-
-        # Make get_commits() always return the same commits mock so assertion on commits.get_page are consistent across multiple calls.
-        repo.get_commits.return_value = commits
-        return repo
-
-    def test_returns_formatted_author_name_and_login(self):
-        # Happy path: result should be "Name (login)".
-        repo = self._make_repo(
-            total_commits=5, per_page=30,
-            oldest_author_name="Carol", oldest_author_login="carol99"
-        )
-        result = _get_creator_from_commits(repo)
-        self.assertEqual(result, "Carol (carol99)")
-
-    def test_zero_commits_returns_na(self):
-        # A repo with no commits should return "N/A" without crashing.
-        repo = MagicMock()
-        commits = MagicMock()
-        commits.totalCount = 0
-        repo.get_commits.return_value = commits
-        result = _get_creator_from_commits(repo)
-        self.assertEqual(result, "N/A")
-
-    def test_correct_last_page_index_is_requested(self):
-        # Critical math check: with 95 commits and 30 per page,
-        # last_page = (95-1)//30 = 3.  Verify get_page(3) is called.
-        total, per_page = 95, 30
-        repo = self._make_repo(
-            total_commits=total, per_page=per_page,
-            oldest_author_name="Dave", oldest_author_login="dave"
-        )
-        _get_creator_from_commits(repo)
-        expected_page = (total - 1) // per_page  # = 3
-        # Use repo.get_commits.return_value (the shared commits mock) so the assertion targets the same object the helper called get_page() on.
-        repo.get_commits.return_value.get_page.assert_called_once_with(expected_page)
-
-    def test_empty_last_page_returns_na(self):
-        # If the last page comes back empty (edge case), return "N/A" gracefully.
-        repo = self._make_repo(
-            total_commits=10, per_page=30,
-            oldest_author_name="", oldest_author_login="",
-            oldest_page_commits=[]
-        )
-        result = _get_creator_from_commits(repo)
-        self.assertEqual(result, "N/A")
-
-    def test_commit_with_no_author_returns_na(self):
-        # GitHub commits can have author=None (e.g. deleted accounts).
-        repo = MagicMock()
-        commits = MagicMock()
-        commits.totalCount = 3
-
-        last_commit = MagicMock()
-        # author can be None on GitHub
-        last_commit.author = None  
-        commits.get_page.return_value = [last_commit]
-
-        requester = MagicMock()
-        requester.per_page = 30
-        repo._requester = requester
-        repo.get_commits.return_value = commits
-
-        result = _get_creator_from_commits(repo)
-        self.assertEqual(result, "N/A")
-
-    def test_falls_back_to_default_per_page_when_requester_missing(self):
-        # If _requester doesn't exist, per_page defaults to 30. With 31 commits: last_page = (31-1)//30 = 1.
-        total = 31
-        # spec=[] means no attributes exist by default
-        repo = MagicMock(spec=[])  
-        commits = MagicMock()
-        commits.totalCount = total
-
-        author = MagicMock()
-        author.name = "Eve"
-        author.login = "eve"
-        last_commit = MagicMock()
-        last_commit.author = author
-        commits.get_page.return_value = [last_commit]
-
-        repo.get_commits = MagicMock(return_value=commits)
-
-        result = _get_creator_from_commits(repo)
-        self.assertEqual(result, "Eve (eve)")
-        commits.get_page.assert_called_once_with(1)
+from gh_repo_exporter import get_repo_creator
 
 
 class TestGetRepoCreator(unittest.TestCase):
     """
     Tests get_repo_creator() end-to-end with a mocked GitHub repo object
-    and an existing_df built from a dummy CSV-style DataFrame — matching
-    the boss's ask for "dummy CSV + mocked GH API calls".
+    and an existing_df built from a dummy CSV-style DataFrame.
 
     Two paths through the function are tested:
       1. Repo IS in existing_df with a valid creator  → return cached value, no API call.
       2. Repo is NOT in existing_df (or has bad data) → fall back to commit history.
     """
-    
-    # Shared helpers
 
     def _make_mock_repo(self, name: str, created_at_str: str) -> MagicMock:
         """
@@ -309,7 +31,7 @@ class TestGetRepoCreator(unittest.TestCase):
                            total: int = 1, per_page: int = 30) -> MagicMock:
         """
         Build a mock commits object whose get_page() returns a single commit
-        with the given author.  Used to wire up the API fallback path.
+        with the given author. Used to wire up the API fallback path.
         """
         commits = MagicMock()
         commits.totalCount = total
@@ -330,10 +52,13 @@ class TestGetRepoCreator(unittest.TestCase):
         """
         return pd.DataFrame(rows, columns=["Repository Name", "Date Created", "Created By"])
 
+    # ------------------------------------------------------------------
     # Cache-hit path: repo already exists in the sheet
+    # ------------------------------------------------------------------
 
     def test_returns_cached_creator_when_repo_in_sheet(self):
-        # If the repo name + date match a sheet row with a valid creator, the cached value should be returned without any API call.
+        # If the repo name + date match a sheet row with a valid creator,
+        # the cached value should be returned without any API call.
         existing_df = self._dummy_existing_df([
             {"Repository Name": "my-repo", "Date Created": "2024-03-01", "Created By": "Alice (alice)"},
         ])
@@ -342,22 +67,7 @@ class TestGetRepoCreator(unittest.TestCase):
         result = get_repo_creator(repo, existing_df)
 
         self.assertEqual(result, "Alice (alice)")
-        repo.get_commits.assert_not_called()  # no API call should have been made
-
-    def test_skips_cache_when_name_matches_but_date_differs(self):
-        # A name match alone is not enough — the date must also match. Different date → should fall through to commit history.
-        existing_df = self._dummy_existing_df([
-            {"Repository Name": "my-repo", "Date Created": "2023-01-01", "Created By": "Alice (alice)"},
-        ])
-        repo = self._make_mock_repo("my-repo", "2024-03-01")
-        commits = self._make_commits_mock("Bob", "bob")
-        repo.get_commits.return_value = commits
-        repo._requester = MagicMock()
-        repo._requester.per_page = 30
-
-        result = get_repo_creator(repo, existing_df)
-
-        self.assertEqual(result, "Bob (bob)")
+        repo.get_commits.assert_not_called()
 
     def test_skips_cache_when_creator_is_na_string(self):
         # "N/A" in the sheet means creator was unknown — should re-fetch from commits.
@@ -375,7 +85,8 @@ class TestGetRepoCreator(unittest.TestCase):
         self.assertEqual(result, "Carol (carol99)")
 
     def test_skips_cache_when_creator_is_nan(self):
-        # NaN in the "Created By" cell (empty sheet cell) must not be returned. The function should fall back to commit history instead.
+        # NaN in the "Created By" cell (empty sheet cell) must not be returned.
+        # The function should fall back to commit history instead.
         existing_df = self._dummy_existing_df([
             {"Repository Name": "my-repo", "Date Created": "2024-03-01", "Created By": float("nan")},
         ])
@@ -389,7 +100,9 @@ class TestGetRepoCreator(unittest.TestCase):
 
         self.assertEqual(result, "Dave (dave42)")
 
+    # ------------------------------------------------------------------
     # Fallback path: repo not in the sheet at all
+    # ------------------------------------------------------------------
 
     def test_fetches_from_commits_when_repo_not_in_sheet(self):
         # Repo is absent from existing_df entirely — must hit commit history.
@@ -420,20 +133,23 @@ class TestGetRepoCreator(unittest.TestCase):
 
         self.assertEqual(result, "Grace (grace)")
 
-    def test_fetches_from_commits_when_existing_df_is_none(self):
-        # existing_df=None is the default — function should handle it gracefully.
+    def test_correct_last_page_index_is_requested(self):
+        # Critical math check: with 95 commits and 30 per page,
+        # last_page = (95-1)//30 = 3. Verify get_page(3) is called.
+        total, per_page = 95, 30
         repo = self._make_mock_repo("my-repo", "2024-03-01")
-        commits = self._make_commits_mock("Heidi", "heidi")
+        commits = self._make_commits_mock("Dave", "dave", total=total, per_page=per_page)
         repo.get_commits.return_value = commits
         repo._requester = MagicMock()
-        repo._requester.per_page = 30
+        repo._requester.per_page = per_page
 
-        result = get_repo_creator(repo, None)
+        get_repo_creator(repo, None)
 
-        self.assertEqual(result, "Heidi (heidi)")
+        expected_page = (total - 1) // per_page  # = 3
+        commits.get_page.assert_called_once_with(expected_page)
 
     def test_returns_na_when_commit_author_is_none(self):
-        # Repo not in sheet, and the oldest commit has no author (deleted account).
+        # Oldest commit has no author (e.g. deleted GitHub account).
         existing_df = self._dummy_existing_df([])
         repo = self._make_mock_repo("ghost-repo", "2024-01-01")
 

--- a/tests/test_repo_core.py
+++ b/tests/test_repo_core.py
@@ -51,10 +51,8 @@ class TestGetRepoCreator(unittest.TestCase):
         Mimics what you'd get from reading a CSV with these columns.
         """
         return pd.DataFrame(rows, columns=["Repository Name", "Date Created", "Created By"])
-
-    # ------------------------------------------------------------------
+    
     # Cache-hit path: repo already exists in the sheet
-    # ------------------------------------------------------------------
 
     def test_returns_cached_creator_when_repo_in_sheet(self):
         # If the repo name + date match a sheet row with a valid creator,
@@ -100,9 +98,7 @@ class TestGetRepoCreator(unittest.TestCase):
 
         self.assertEqual(result, "Dave (dave42)")
 
-    # ------------------------------------------------------------------
     # Fallback path: repo not in the sheet at all
-    # ------------------------------------------------------------------
 
     def test_fetches_from_commits_when_repo_not_in_sheet(self):
         # Repo is absent from existing_df entirely — must hit commit history.
@@ -132,6 +128,21 @@ class TestGetRepoCreator(unittest.TestCase):
         result = get_repo_creator(repo, existing_df)
 
         self.assertEqual(result, "Grace (grace)")
+        
+    def test_falls_back_to_commits_when_existing_df_missing_columns(self):
+        # DataFrame exists but has wrong column names (e.g. bad sheet export).
+        # Should fall through to commit history, not raise or return "N/A" silently.
+        existing_df = pd.DataFrame([{"Repo": "my-repo", "Created": "2024-03-01"}])
+        repo = self._make_mock_repo("my-repo", "2024-03-01")
+        commits = self._make_commits_mock("Henry", "henry99")
+        repo.get_commits.return_value = commits
+        repo._requester = MagicMock()
+        repo._requester.per_page = 30
+
+        result = get_repo_creator(repo, existing_df)
+
+        self.assertEqual(result, "Henry (henry99)")
+        repo.get_commits.assert_called()
 
     def test_correct_last_page_index_is_requested(self):
         # Critical math check: with 95 commits and 30 per page,

--- a/tests/test_repo_core.py
+++ b/tests/test_repo_core.py
@@ -1,0 +1,468 @@
+import unittest
+from unittest.mock import MagicMock, patch, PropertyMock
+import pandas as pd
+import math
+
+from gh_repo_exporter import extract_display_name, get_repo_creator
+
+# --- Fix 1: safe lambda (main()) ---
+# The old code called .apply(extract_display_name) directly.
+# If a "Repository Name" cell is empty, pandas fills it with NaN (a float),
+# which causes extract_display_name to raise TypeError inside re.search().
+# Because that runs inside a broad try/except, one bad row silently empties
+# existing_df and disables the whole "skip already-fetched repos" optimization.
+# Fix: only call extract_display_name when the value is actually a string.
+
+def apply_extract_display_name_safe(series: pd.Series) -> pd.Series:
+    """Mirrors the fixed lambda: extract only if value is a str, else ''."""
+    return series.apply(
+        lambda v: extract_display_name(v) if isinstance(v, str) else ""
+    )
+
+# --- Fix 2: NaN-safe "Created By" lookup (get_repo_creator()) ---
+# The old code did match.iloc[0]["Created By"], which is NaN when the cell is
+# empty.  `if existing_creator` treats NaN as truthy (NaN != 0 in Python), so
+# the function returned a raw float NaN instead of falling back to commit history.
+# Fix: use .get() + isinstance guard so only real strings are returned.
+
+def _extract_creator_from_match(match_row) -> str | None:
+    """
+    Mirrors the fixed lines 70-74 in get_repo_creator.
+    Returns the creator string if valid, otherwise None (triggers fallback).
+    """
+    existing_creator = match_row.get("Created By")
+    if isinstance(existing_creator, str):
+        existing_creator = existing_creator.strip()
+        if existing_creator and existing_creator != "N/A":
+            return existing_creator
+    return None
+
+
+# --- Fix 3: paginated commit fallback (get_repo_creator()) ---
+# The old fallback used commits.reversed[0], which forces PyGitHub to traverse
+# the entire commit history — very slow for large repos (issue #38).
+# Fix: use totalCount + get_page(last_page) to jump straight to the oldest
+# page of commits with a single extra API call.
+
+def _get_creator_from_commits(repo) -> str:
+    """
+    Mirrors the fixed fallback block (lines 77-87).
+    Separated into its own function for unit-testability.
+    """
+    commits = repo.get_commits()
+    total = commits.totalCount
+    if not total:
+        return "N/A"
+
+    # Jump directly to the last page instead of reversing the whole history.
+    per_page = getattr(getattr(repo, "_requester", None), "per_page", 30) or 30
+    last_page = (total - 1) // per_page
+    oldest_page = commits.get_page(last_page)
+    oldest_commit = oldest_page[-1] if oldest_page else None
+    author = oldest_commit.author if oldest_commit else None
+
+    return f"{author.name} ({author.login})" if author else "N/A"
+
+# Tests
+
+class TestApplyExtractDisplayNameSafe(unittest.TestCase):
+    """
+    Covers the isinstance(v, str) guard added to the .apply() call in main().
+
+    Each test feeds a pandas Series into apply_extract_display_name_safe and
+    checks the output — no GitHub or Sheets API calls needed.
+    """
+
+    def test_normal_hyperlink_values_are_extracted(self):
+        # Happy path: well-formed HYPERLINK formulas should extract the repo name.
+        series = pd.Series([
+            '=HYPERLINK("https://github.com/org/repo-a", "repo-a")',
+            '=HYPERLINK("https://github.com/org/repo-b", "repo-b")',
+        ])
+        result = apply_extract_display_name_safe(series)
+        self.assertEqual(result[0], "repo-a")
+        self.assertEqual(result[1], "repo-b")
+
+    def test_nan_values_become_empty_string(self):
+        # Core bug: NaN must not raise TypeError; it should silently become ''.
+        series = pd.Series([
+            '=HYPERLINK("https://github.com/org/repo-a", "repo-a")',
+            float("nan"),
+        ])
+        result = apply_extract_display_name_safe(series)
+        self.assertEqual(result[0], "repo-a")
+        self.assertEqual(result[1], "")
+
+    def test_none_values_become_empty_string(self):
+        # None is also not a str, so it should fall through to "".
+        series = pd.Series([None, '=HYPERLINK("https://github.com/org/r", "r")'])
+        result = apply_extract_display_name_safe(series)
+        self.assertEqual(result[0], "")
+        self.assertEqual(result[1], "r")
+
+    def test_all_nan_series_returns_all_empty_strings(self):
+        # All-NaN series: every cell should become "" without raising.
+        series = pd.Series([float("nan"), float("nan")])
+        result = apply_extract_display_name_safe(series)
+        self.assertTrue((result == "").all())
+
+    def test_plain_string_without_hyperlink_syntax_returns_itself(self):
+        # If a cell holds a plain name (no HYPERLINK formula), the regex in extract_display_name finds no match and returns the original value.
+        series = pd.Series(["just-a-name"])
+        result = apply_extract_display_name_safe(series)
+        self.assertEqual(result[0], "just-a-name")
+
+
+class TestExtractCreatorFromMatch(unittest.TestCase):
+    """
+    Covers the isinstance + .strip() guard added to get_repo_creator() lines 70-74.
+
+    _make_row() builds a minimal pandas Series that mimics match.iloc[0] so
+    we can test the extraction logic without touching the GitHub API.
+    """
+
+    def _make_row(self, value):
+        """Return a pandas Series that mimics match.iloc[0]."""
+        return pd.Series({"Repository Name": "repo", "Date Created": "2024-01-01",
+                          "Created By": value})
+
+    def test_valid_creator_string_is_returned(self):
+        # Happy path: a clean "Name (login)" string comes back unchanged.
+        row = self._make_row("Alice (alice)")
+        self.assertEqual(_extract_creator_from_match(row), "Alice (alice)")
+
+    def test_creator_with_leading_trailing_whitespace_is_stripped(self):
+        # .strip() should remove surrounding whitespace before returning.
+        row = self._make_row("  Bob (bob)  ")
+        self.assertEqual(_extract_creator_from_match(row), "Bob (bob)")
+
+    def test_nan_creator_returns_none(self):
+        # Core bug: NaN is truthy in Python, so the old code returned raw NaN.The fix must return None so the caller falls back to commit history.
+        row = self._make_row(float("nan"))
+        self.assertIsNone(_extract_creator_from_match(row))
+
+    def test_na_string_returns_none(self):
+        # "N/A" means no creator was found previously; trigger fallback.
+        row = self._make_row("N/A")
+        self.assertIsNone(_extract_creator_from_match(row))
+
+    def test_empty_string_returns_none(self):
+        # Empty string is not a useful creator value; trigger fallback.
+        row = self._make_row("")
+        self.assertIsNone(_extract_creator_from_match(row))
+
+    def test_whitespace_only_string_returns_none(self):
+        # After .strip(), "   " becomes "" which is falsy and return None.
+        row = self._make_row("   ")
+        self.assertIsNone(_extract_creator_from_match(row))
+
+    def test_missing_key_returns_none(self):
+        # If the "Created By" column is absent entirely, .get() returns None (a dict/Series key miss), which is not a str — so we return None.
+        row = pd.Series({"Repository Name": "repo"})
+        self.assertIsNone(_extract_creator_from_match(row))
+
+
+class TestGetCreatorFromCommits(unittest.TestCase):
+    """
+    Covers the paginated commit fallback that replaces commits.reversed[0].
+
+    _make_repo() builds a MagicMock repo whose get_commits() return value is
+    pre-wired with a totalCount and a get_page() result, so no real API calls
+    are made.  We then assert on what _get_creator_from_commits returns AND
+    on which page index it actually requested.
+    """
+
+    def _make_repo(self, total_commits, per_page, oldest_author_name,
+                   oldest_author_login, oldest_page_commits=None):
+        """Build a minimal mock repo whose commit pagination is pre-configured."""
+        repo = MagicMock()
+        commits = MagicMock()
+        commits.totalCount = total_commits
+
+        if oldest_page_commits is None:
+            author = MagicMock()
+            author.name = oldest_author_name
+            author.login = oldest_author_login
+            last_commit = MagicMock()
+            last_commit.author = author
+            oldest_page_commits = [last_commit]
+
+        commits.get_page.return_value = oldest_page_commits
+
+        # Wire per_page onto _requester so the helper can read it.
+        requester = MagicMock()
+        requester.per_page = per_page
+        repo._requester = requester
+
+        # Make get_commits() always return the same commits mock so assertion on commits.get_page are consistent across multiple calls.
+        repo.get_commits.return_value = commits
+        return repo
+
+    def test_returns_formatted_author_name_and_login(self):
+        # Happy path: result should be "Name (login)".
+        repo = self._make_repo(
+            total_commits=5, per_page=30,
+            oldest_author_name="Carol", oldest_author_login="carol99"
+        )
+        result = _get_creator_from_commits(repo)
+        self.assertEqual(result, "Carol (carol99)")
+
+    def test_zero_commits_returns_na(self):
+        # A repo with no commits should return "N/A" without crashing.
+        repo = MagicMock()
+        commits = MagicMock()
+        commits.totalCount = 0
+        repo.get_commits.return_value = commits
+        result = _get_creator_from_commits(repo)
+        self.assertEqual(result, "N/A")
+
+    def test_correct_last_page_index_is_requested(self):
+        # Critical math check: with 95 commits and 30 per page,
+        # last_page = (95-1)//30 = 3.  Verify get_page(3) is called.
+        total, per_page = 95, 30
+        repo = self._make_repo(
+            total_commits=total, per_page=per_page,
+            oldest_author_name="Dave", oldest_author_login="dave"
+        )
+        _get_creator_from_commits(repo)
+        expected_page = (total - 1) // per_page  # = 3
+        # Use repo.get_commits.return_value (the shared commits mock) so the assertion targets the same object the helper called get_page() on.
+        repo.get_commits.return_value.get_page.assert_called_once_with(expected_page)
+
+    def test_empty_last_page_returns_na(self):
+        # If the last page comes back empty (edge case), return "N/A" gracefully.
+        repo = self._make_repo(
+            total_commits=10, per_page=30,
+            oldest_author_name="", oldest_author_login="",
+            oldest_page_commits=[]
+        )
+        result = _get_creator_from_commits(repo)
+        self.assertEqual(result, "N/A")
+
+    def test_commit_with_no_author_returns_na(self):
+        # GitHub commits can have author=None (e.g. deleted accounts).
+        repo = MagicMock()
+        commits = MagicMock()
+        commits.totalCount = 3
+
+        last_commit = MagicMock()
+        # author can be None on GitHub
+        last_commit.author = None  
+        commits.get_page.return_value = [last_commit]
+
+        requester = MagicMock()
+        requester.per_page = 30
+        repo._requester = requester
+        repo.get_commits.return_value = commits
+
+        result = _get_creator_from_commits(repo)
+        self.assertEqual(result, "N/A")
+
+    def test_falls_back_to_default_per_page_when_requester_missing(self):
+        # If _requester doesn't exist, per_page defaults to 30. With 31 commits: last_page = (31-1)//30 = 1.
+        total = 31
+        # spec=[] means no attributes exist by default
+        repo = MagicMock(spec=[])  
+        commits = MagicMock()
+        commits.totalCount = total
+
+        author = MagicMock()
+        author.name = "Eve"
+        author.login = "eve"
+        last_commit = MagicMock()
+        last_commit.author = author
+        commits.get_page.return_value = [last_commit]
+
+        repo.get_commits = MagicMock(return_value=commits)
+
+        result = _get_creator_from_commits(repo)
+        self.assertEqual(result, "Eve (eve)")
+        commits.get_page.assert_called_once_with(1)
+
+
+class TestGetRepoCreator(unittest.TestCase):
+    """
+    Tests get_repo_creator() end-to-end with a mocked GitHub repo object
+    and an existing_df built from a dummy CSV-style DataFrame — matching
+    the boss's ask for "dummy CSV + mocked GH API calls".
+
+    Two paths through the function are tested:
+      1. Repo IS in existing_df with a valid creator  → return cached value, no API call.
+      2. Repo is NOT in existing_df (or has bad data) → fall back to commit history.
+    """
+    
+    # Shared helpers
+
+    def _make_mock_repo(self, name: str, created_at_str: str) -> MagicMock:
+        """
+        Build a minimal mock GitHub repo object.
+        created_at must be a real datetime because get_repo_creator calls
+        repo.created_at.strftime("%Y-%m-%d") to match against the sheet.
+        """
+        from datetime import datetime
+        repo = MagicMock()
+        repo.name = name
+        repo.created_at = datetime.strptime(created_at_str, "%Y-%m-%d")
+        return repo
+
+    def _make_commits_mock(self, author_name: str, author_login: str,
+                           total: int = 1, per_page: int = 30) -> MagicMock:
+        """
+        Build a mock commits object whose get_page() returns a single commit
+        with the given author.  Used to wire up the API fallback path.
+        """
+        commits = MagicMock()
+        commits.totalCount = total
+
+        author = MagicMock()
+        author.name = author_name
+        author.login = author_login
+        commit = MagicMock()
+        commit.author = author
+        commits.get_page.return_value = [commit]
+        return commits
+
+    def _dummy_existing_df(self, rows: list[dict]) -> pd.DataFrame:
+        """
+        Build a DataFrame that looks like the three columns loaded from the
+        Google Sheet in main() — the same shape get_repo_creator receives.
+        Mimics what you'd get from reading a CSV with these columns.
+        """
+        return pd.DataFrame(rows, columns=["Repository Name", "Date Created", "Created By"])
+
+    # Cache-hit path: repo already exists in the sheet
+
+    def test_returns_cached_creator_when_repo_in_sheet(self):
+        # If the repo name + date match a sheet row with a valid creator, the cached value should be returned without any API call.
+        existing_df = self._dummy_existing_df([
+            {"Repository Name": "my-repo", "Date Created": "2024-03-01", "Created By": "Alice (alice)"},
+        ])
+        repo = self._make_mock_repo("my-repo", "2024-03-01")
+
+        result = get_repo_creator(repo, existing_df)
+
+        self.assertEqual(result, "Alice (alice)")
+        repo.get_commits.assert_not_called()  # no API call should have been made
+
+    def test_skips_cache_when_name_matches_but_date_differs(self):
+        # A name match alone is not enough — the date must also match. Different date → should fall through to commit history.
+        existing_df = self._dummy_existing_df([
+            {"Repository Name": "my-repo", "Date Created": "2023-01-01", "Created By": "Alice (alice)"},
+        ])
+        repo = self._make_mock_repo("my-repo", "2024-03-01")
+        commits = self._make_commits_mock("Bob", "bob")
+        repo.get_commits.return_value = commits
+        repo._requester = MagicMock()
+        repo._requester.per_page = 30
+
+        result = get_repo_creator(repo, existing_df)
+
+        self.assertEqual(result, "Bob (bob)")
+
+    def test_skips_cache_when_creator_is_na_string(self):
+        # "N/A" in the sheet means creator was unknown — should re-fetch from commits.
+        existing_df = self._dummy_existing_df([
+            {"Repository Name": "my-repo", "Date Created": "2024-03-01", "Created By": "N/A"},
+        ])
+        repo = self._make_mock_repo("my-repo", "2024-03-01")
+        commits = self._make_commits_mock("Carol", "carol99")
+        repo.get_commits.return_value = commits
+        repo._requester = MagicMock()
+        repo._requester.per_page = 30
+
+        result = get_repo_creator(repo, existing_df)
+
+        self.assertEqual(result, "Carol (carol99)")
+
+    def test_skips_cache_when_creator_is_nan(self):
+        # NaN in the "Created By" cell (empty sheet cell) must not be returned. The function should fall back to commit history instead.
+        existing_df = self._dummy_existing_df([
+            {"Repository Name": "my-repo", "Date Created": "2024-03-01", "Created By": float("nan")},
+        ])
+        repo = self._make_mock_repo("my-repo", "2024-03-01")
+        commits = self._make_commits_mock("Dave", "dave42")
+        repo.get_commits.return_value = commits
+        repo._requester = MagicMock()
+        repo._requester.per_page = 30
+
+        result = get_repo_creator(repo, existing_df)
+
+        self.assertEqual(result, "Dave (dave42)")
+
+    # Fallback path: repo not in the sheet at all
+
+    def test_fetches_from_commits_when_repo_not_in_sheet(self):
+        # Repo is absent from existing_df entirely — must hit commit history.
+        existing_df = self._dummy_existing_df([
+            {"Repository Name": "other-repo", "Date Created": "2024-03-01", "Created By": "Eve (eve)"},
+        ])
+        repo = self._make_mock_repo("my-repo", "2024-03-01")
+        commits = self._make_commits_mock("Frank", "frankdev")
+        repo.get_commits.return_value = commits
+        repo._requester = MagicMock()
+        repo._requester.per_page = 30
+
+        result = get_repo_creator(repo, existing_df)
+
+        self.assertEqual(result, "Frank (frankdev)")
+        repo.get_commits.assert_called()
+
+    def test_fetches_from_commits_when_existing_df_is_empty(self):
+        # Empty DataFrame (e.g. first-ever run, sheet has no data yet).
+        existing_df = pd.DataFrame(columns=["Repository Name", "Date Created", "Created By"])
+        repo = self._make_mock_repo("brand-new-repo", "2024-06-01")
+        commits = self._make_commits_mock("Grace", "grace")
+        repo.get_commits.return_value = commits
+        repo._requester = MagicMock()
+        repo._requester.per_page = 30
+
+        result = get_repo_creator(repo, existing_df)
+
+        self.assertEqual(result, "Grace (grace)")
+
+    def test_fetches_from_commits_when_existing_df_is_none(self):
+        # existing_df=None is the default — function should handle it gracefully.
+        repo = self._make_mock_repo("my-repo", "2024-03-01")
+        commits = self._make_commits_mock("Heidi", "heidi")
+        repo.get_commits.return_value = commits
+        repo._requester = MagicMock()
+        repo._requester.per_page = 30
+
+        result = get_repo_creator(repo, None)
+
+        self.assertEqual(result, "Heidi (heidi)")
+
+    def test_returns_na_when_commit_author_is_none(self):
+        # Repo not in sheet, and the oldest commit has no author (deleted account).
+        existing_df = self._dummy_existing_df([])
+        repo = self._make_mock_repo("ghost-repo", "2024-01-01")
+
+        commits = MagicMock()
+        commits.totalCount = 1
+        commit = MagicMock()
+        commit.author = None
+        commits.get_page.return_value = [commit]
+        repo.get_commits.return_value = commits
+        repo._requester = MagicMock()
+        repo._requester.per_page = 30
+
+        result = get_repo_creator(repo, existing_df)
+
+        self.assertEqual(result, "N/A")
+
+    def test_returns_na_when_repo_has_no_commits(self):
+        # Brand-new empty repo with zero commits should return "N/A" cleanly.
+        existing_df = self._dummy_existing_df([])
+        repo = self._make_mock_repo("empty-repo", "2024-01-01")
+
+        commits = MagicMock()
+        commits.totalCount = 0
+        repo.get_commits.return_value = commits
+
+        result = get_repo_creator(repo, existing_df)
+
+        self.assertEqual(result, "N/A")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_repo_core.py
+++ b/tests/test_repo_core.py
@@ -154,13 +154,15 @@ class TestGetRepoCreator(unittest.TestCase):
         repo._requester = MagicMock()
         repo._requester.per_page = per_page
 
-        get_repo_creator(repo, None)
+        result = get_repo_creator(repo, None)
+        
+        self.assertEquals(result, "Dave (dave)")
 
         expected_page = (total - 1) // per_page  # = 3
         commits.get_page.assert_called_once_with(expected_page)
 
     def test_returns_na_when_commit_author_is_none(self):
-        # Oldest commit has no author (e.g. deleted GitHub account).
+        # Oldest commit has no author (e.g. deleted GitHub account or user changed their GitHub name/display name).
         existing_df = self._dummy_existing_df([])
         repo = self._make_mock_repo("ghost-repo", "2024-01-01")
 

--- a/tests/test_repo_core.py
+++ b/tests/test_repo_core.py
@@ -156,7 +156,7 @@ class TestGetRepoCreator(unittest.TestCase):
 
         result = get_repo_creator(repo, None)
         
-        self.assertEquals(result, "Dave (dave)")
+        self.assertEqual(result, "Dave (dave)")
 
         expected_page = (total - 1) // per_page  # = 3
         commits.get_page.assert_called_once_with(expected_page)


### PR DESCRIPTION
#38 

This updates how we determine the creator of a repository. 

The `main()` function now loads existing sheet data for Repository Name, Date Created, and Created By, and normalizes repository names with extract_display_name to match sheet entries. In `get_repo_creator()`, the code first checks if a creator is already recorded in the sheet and reuses it if available, only falling back to the first commit author if necessary. These changes make the retrieval process for creator information much faster by avoiding recomputing for repositories that have already been processed.