### PR TITLE
Added a website check function to filter external URLs from Website Reference column

### DIFF
--- a/gh_repo_exporter.py
+++ b/gh_repo_exporter.py
@@ -262,7 +262,7 @@ def get_associated_paper(readme: str, homepage: str | None = None) -> str:
         # Check About section URL as fallback  
         if homepage:
             for pattern in url_patterns:
-                if re.search(pattern, homepage, re.IGNORECASE):
+                if re.search(pattern, homepage.lower(), re.IGNORECASE):
                     cleaned = homepage.rstrip(").],};:>\"'")
                     return f'=HYPERLINK("{cleaned}", "Yes")'
         return "No"
@@ -282,11 +282,11 @@ def get_website_reference(homepage: str | None) -> str:
             "doi.org",
         ]
         
-        for pattern in external_patterns:
-            if pattern in homepage.lower():
-                return "No"
+        if any(pattern in homepage.lower() for pattern in external_patterns):
+            return "No"
         
-        return f'=HYPERLINK("{homepage}", "Yes")'
+        cleaned = homepage.rstrip(").],};:>\"'")
+        return f'=HYPERLINK("{cleaned}", "Yes")'
     except Exception:
         return "No"
        

--- a/gh_repo_exporter.py
+++ b/gh_repo_exporter.py
@@ -262,7 +262,6 @@ def get_associated_paper(readme: str, homepage: str | None = None) -> str:
         # Check About section URL as fallback  
         if homepage:
             for pattern in url_patterns:
-                if re.search(pattern, homepage.lower(), re.IGNORECASE):
                 if re.search(pattern, homepage, re.IGNORECASE):
                     cleaned = homepage.rstrip(").],};:>\"'")
                     return f'=HYPERLINK("{cleaned}", "Yes")'

--- a/gh_repo_exporter.py
+++ b/gh_repo_exporter.py
@@ -232,7 +232,7 @@ def get_primary_language(repo) -> str:
     except Exception:
         return "N/A"
 
-def get_associated_paper(readme: str) -> str:
+def get_associated_paper(readme: str, homepage: str | None = None) -> str:
     try:
         url_patterns = [
             r"https?://arxiv\.org/[A-Za-z0-9_\-./]+",
@@ -247,6 +247,7 @@ def get_associated_paper(readme: str) -> str:
         # checks for [<name>](<url>)
         markdown_link_pattern = r"\[([^\]]+)\]\((.*?)\)"
 
+        # Check README for paper-associated links
         for label, url in re.findall(markdown_link_pattern, readme):
             # Only accept label == "paper" or "arXiv" (case-insensitive)
             if label.strip().lower() not in {"paper", "arxiv"}:
@@ -257,11 +258,38 @@ def get_associated_paper(readme: str) -> str:
                 if re.search(pattern, url):
                     cleaned = url.rstrip(").],};:>\"'")
                     return f'=HYPERLINK("{cleaned}", "Yes")'
+                
+        # Check About section URL as fallback  
+        if homepage:
+            for pattern in url_patterns:
+                if re.search(pattern, homepage, re.IGNORECASE):
+                    cleaned = homepage.rstrip(").],};:>\"'")
+                    return f'=HYPERLINK("{cleaned}", "Yes")'
         return "No"
     except Exception:
         return "No"
     
-    
+def get_website_reference(homepage: str | None) -> str:
+    try:
+        if not homepage:
+            return "No"
+        
+        # Return "No" if homepage is a paper, dataset, or model link instead of an actual website
+        external_patterns = [
+            "arxiv.org",
+            "huggingface.co",
+            "hf.co",
+            "doi.org",
+        ]
+        
+        for pattern in external_patterns:
+            if pattern in homepage.lower():
+                return "No"
+        
+        return f'=HYPERLINK("{homepage}", "Yes")'
+    except Exception:
+        return "No"
+       
 def get_repo_info(repo) -> dict[str, str | int]:
     try:
         readme_content_lower = repo.get_readme().decoded_content.decode("utf-8", errors="ignore").lower()
@@ -289,10 +317,10 @@ def get_repo_info(repo) -> dict[str, str | int]:
         "Visibility": "Private" if repo.private else "Public",
         "Forks": "Yes" if repo.fork else "No",
         "Inactive": is_inactive(repo),
-        "Website Reference": f'=HYPERLINK("{repo.homepage}", "Yes")' if repo.homepage else "No",
+        "Website Reference": get_website_reference(repo.homepage),
         "Dataset": get_dataset(readme_content_lower, repo.name.lower()),
         "Model": get_model(readme_content_lower),
-        "Paper Association": get_associated_paper(readme_content_lower),
+        "Paper Association": get_associated_paper(readme_content_lower, repo.homepage),
         "DOI for GitHub Repo": has_doi(repo),
     }
 

--- a/gh_repo_exporter.py
+++ b/gh_repo_exporter.py
@@ -255,7 +255,7 @@ def get_associated_paper(readme: str, homepage: str | None = None) -> str:
 
             # Check if URL matches a paper source
             for pattern in url_patterns:
-                if re.search(pattern, url):
+                if re.search(pattern, url, re.IGNORECASE):
                     cleaned = url.rstrip(").],};:>\"'")
                     return f'=HYPERLINK("{cleaned}", "Yes")'
                 


### PR DESCRIPTION
#45

Added a new `get_website_reference` function that filters out external resource links (arxiv, HuggingFace, DOI) from the Website Reference column. It checks if the URL contains any of those external patterns as a substring and returns "No" if so.

Note: the `get_associated_paper` changes showing in this PR's are not actual changes because main already has identical code for that function. The only real change in this PR is the new `get_website_reference` function and its usage in `get_repo_info`.