### PR TITLE
bugfix/ improve detection of paper links & rank paper links by publisher, DOI, and position

### DIFF
--- a/gh_repo_exporter.py
+++ b/gh_repo_exporter.py
@@ -302,6 +302,7 @@ DOI_REGISTRANT_PREFIXES = {
     "1007": "Springer",
     "1145": "ACM",
     "1101": "bioRxiv / Cold Spring Harbor",
+    "1080": "Taylor & Francis",
 }
 
 _DOI_PUB_CODES = "|".join(DOI_REGISTRANT_PREFIXES)
@@ -337,6 +338,8 @@ def get_associated_paper(readme: str, homepage: str | None = None) -> str:
             _KNOWN_PUBLISHER_DOI_PATTERN,
             r"https?://link\.springer\.com/[A-Za-z0-9_\-./]+",
             r"https?://www\.nature\.com/[A-Za-z0-9_\-./]+",
+            r"https?://www\.biorxiv\.org/[A-Za-z0-9_\-./]+",
+            r"https?://www\.pnas\.org/[A-Za-z0-9_\-./]+",
             r"https?://dl\.acm\.org/[A-Za-z0-9_\-./]+",
             r"https?://ieeexplore\.ieee\.org/[A-Za-z0-9_\-./]+",
             r"https?://www\.researchgate\.net/[A-Za-z0-9_\-./]+",

--- a/gh_repo_exporter.py
+++ b/gh_repo_exporter.py
@@ -299,8 +299,9 @@ def _is_valid_paper_link_for_doi(url: str) -> bool:
     which belongs in the "DOI for GitHub Repo" column. 
     """
 
+    # the denylist
     if "doi.org" in url.lower():
-        return "arxiv" in url.lower()
+        return "zenodo" not in url.lower()
     return True
 
 def _first_valid_paper_match(patterns: list[str], text: str) -> str | None:

--- a/gh_repo_exporter.py
+++ b/gh_repo_exporter.py
@@ -289,33 +289,38 @@ def get_primary_language(repo) -> str:
         return max(languages, key=languages.get)
     except Exception:
         return "N/A"
-    
-def _is_valid_paper_link_for_doi(url: str) -> bool:
-    """
-    Checks whether a matched URL should count as a paper association.
-    
-    doi.org links are only accepted if they contain "arxiv" (e.g. an
-    arXiv-issued DOI). This filters out non-paper doi.org links (Zenodo DOIs) 
-    which belongs in the "DOI for GitHub Repo" column. 
-    """
 
-    # the denylist
-    if "doi.org" in url.lower():
-        return "zenodo" not in url.lower()
-    return True
+# DOI registrant prefixes for known paper-hosting publishers.
+DOI_REGISTRANT_PREFIXES = {
+    "48550": "arXiv",
+    "1109": "IEEE",
+    "1111": "Wiley",
+    "1073": "PNAS",
+    "1126": "Science / AAAS",
+    "7717": "PeerJ",
+    "1038": "Nature",
+    "1007": "Springer",
+    "1145": "ACM",
+    "1101": "bioRxiv / Cold Spring Harbor",
+}
+
+_DOI_PUB_CODES = "|".join(DOI_REGISTRANT_PREFIXES)
+_KNOWN_PUBLISHER_DOI_PATTERN = (
+    rf"https?://doi\.org/10\.(?:{_DOI_PUB_CODES})/[A-Za-z0-9\-./]+"
+)
 
 def _first_valid_paper_match(patterns: list[str], text: str) -> str | None:
     """
-    Searches text for the first URL matching any pattern in its priority order
-    that passes _is_valid_paper_link_for_doi().
+    Searches text for the first URL matching any pattern in its priority
+    order. Patterns are constructed to only match known-good sources, so
+    any match found is valid by construction.
     
     Returns the cleaned URL string if found, otherwise None.
     """
     for pattern in patterns:
-        for match in re.finditer(pattern, text, re.IGNORECASE):
-            cleaned = match.group(0).rstrip(").],};:>\"'")
-            if _is_valid_paper_link_for_doi(cleaned):
-                return cleaned
+        match = re.search(pattern, text, re.IGNORECASE)
+        if match:
+            return match.group(0).rstrip(").],};:>\"'")
     return None
 
 def get_associated_paper(readme: str, homepage: str | None = None) -> str:
@@ -329,7 +334,7 @@ def get_associated_paper(readme: str, homepage: str | None = None) -> str:
     try:
         url_patterns = [
             r"https?://arxiv\.org/[A-Za-z0-9_\-./]+",
-            r"https?://doi\.org/[A-Za-z0-9_\-./]+",
+            _KNOWN_PUBLISHER_DOI_PATTERN,
             r"https?://link\.springer\.com/[A-Za-z0-9_\-./]+",
             r"https?://www\.nature\.com/[A-Za-z0-9_\-./]+",
             r"https?://dl\.acm\.org/[A-Za-z0-9_\-./]+",

--- a/gh_repo_exporter.py
+++ b/gh_repo_exporter.py
@@ -302,21 +302,13 @@ def get_associated_paper(readme: str, homepage: str | None = None) -> str:
             r"https?://www\.researchgate\.net/[A-Za-z0-9_\-./]+",
         ]
 
-        # checks for [<name>](<url>)
-        markdown_link_pattern = r"\[([^\]]+)\]\((.*?)\)"
+        # Check README for paper-associated links regardless of surrounding markdown formatting
+        for pattern in url_patterns:
+            match = re.search(pattern, readme, re.IGNORECASE)
+            if match:
+                cleaned = match.group(0).rstrip(").],};:>\"'")
+                return f'=HYPERLINK("{cleaned}", "Yes")'
 
-        # Check README for paper-associated links
-        for label, url in re.findall(markdown_link_pattern, readme):
-            # Only accept label == "paper" or "arXiv" (case-insensitive)
-            if label.strip().lower() not in {"paper", "arxiv"}:
-                continue
-
-            # Check if URL matches a paper source
-            for pattern in url_patterns:
-                if re.search(pattern, url, re.IGNORECASE):
-                    cleaned = url.rstrip(").],};:>\"'")
-                    return f'=HYPERLINK("{cleaned}", "Yes")'
-                
         # Check About section URL as fallback  
         if homepage:
             for pattern in url_patterns:

--- a/gh_repo_exporter.py
+++ b/gh_repo_exporter.py
@@ -289,8 +289,42 @@ def get_primary_language(repo) -> str:
         return max(languages, key=languages.get)
     except Exception:
         return "N/A"
+    
+def _is_valid_paper_link_for_doi(url: str) -> bool:
+    """
+    Checks whether a matched URL should count as a paper association.
+    
+    doi.org links are only accepted if they contain "arxiv" (e.g. an
+    arXiv-issued DOI). This filters out non-paper doi.org links (Zenodo DOIs) 
+    which belongs in the "DOI for GitHub Repo" column. 
+    """
+
+    if "doi.org" in url.lower():
+        return "arxiv" in url.lower()
+    return True
+
+def _first_valid_paper_match(patterns: list[str], text: str) -> str | None:
+    """
+    Searches text for the first URL matching any pattern in its priority order
+    that passes _is_valid_paper_link_for_doi().
+    
+    Returns the cleaned URL string if found, otherwise None.
+    """
+    for pattern in patterns:
+        for match in re.finditer(pattern, text, re.IGNORECASE):
+            cleaned = match.group(0).rstrip(").],};:>\"'")
+            if _is_valid_paper_link_for_doi(cleaned):
+                return cleaned
+    return None
 
 def get_associated_paper(readme: str, homepage: str | None = None) -> str:
+    """
+    Checks the README and then homepage as fallback for a link to an
+    associated paper.
+    
+    Returns an =HYPERLINK(...) formula pointing to the paper if found,
+    otherwise "No".
+    """
     try:
         url_patterns = [
             r"https?://arxiv\.org/[A-Za-z0-9_\-./]+",
@@ -302,19 +336,15 @@ def get_associated_paper(readme: str, homepage: str | None = None) -> str:
             r"https?://www\.researchgate\.net/[A-Za-z0-9_\-./]+",
         ]
 
-        # Check README for paper-associated links regardless of surrounding markdown formatting
-        for pattern in url_patterns:
-            match = re.search(pattern, readme, re.IGNORECASE)
-            if match:
-                cleaned = match.group(0).rstrip(").],};:>\"'")
+        cleaned = _first_valid_paper_match(url_patterns, readme)
+        if cleaned:
+            return f'=HYPERLINK("{cleaned}", "Yes")'
+        
+        if homepage:
+            cleaned = _first_valid_paper_match(url_patterns, homepage)
+            if cleaned:
                 return f'=HYPERLINK("{cleaned}", "Yes")'
 
-        # Check About section URL as fallback  
-        if homepage:
-            for pattern in url_patterns:
-                if re.search(pattern, homepage, re.IGNORECASE):
-                    cleaned = homepage.rstrip(").],};:>\"'")
-                    return f'=HYPERLINK("{cleaned}", "Yes")'
         return "No"
     except Exception:
         return "No"

--- a/gh_repo_exporter.py
+++ b/gh_repo_exporter.py
@@ -315,16 +315,6 @@ PAPER_HOST_URL_PATTERNS = {
     r"https?://www\.researchgate\.net/[A-Za-z0-9_\-./]+": "ResearchGate",
 }
 
-# Direct (non-DOI) URL patterns for known paper-hosting publishers.
-PAPER_HOST_URL_PATTERNS = {
-    r"https?://arxiv\.org/[A-Za-z0-9_\-./]+": "arXiv",
-    r"https?://link\.springer\.com/[A-Za-z0-9_\-./]+": "Springer",
-    r"https?://www\.nature\.com/[A-Za-z0-9_\-./]+": "Nature",
-    r"https?://dl\.acm\.org/[A-Za-z0-9_\-./]+": "ACM",
-    r"https?://ieeexplore\.ieee\.org/[A-Za-z0-9_\-./]+": "IEEE",
-    r"https?://www\.researchgate\.net/[A-Za-z0-9_\-./]+": "ResearchGate",
-}
-
 _DOI_PUB_CODES = "|".join(DOI_REGISTRANT_PREFIXES)
 _KNOWN_PUBLISHER_DOI_PATTERN = (
     rf"https?://doi\.org/10\.(?:{_DOI_PUB_CODES})/[A-Za-z0-9\-./]+"
@@ -356,15 +346,8 @@ def get_associated_paper(readme: str, homepage: str | None = None) -> str:
         url_patterns = [
             *PAPER_HOST_URL_PATTERNS,
             _KNOWN_PUBLISHER_DOI_PATTERN,
-            r"https?://link\.springer\.com/[A-Za-z0-9_\-./]+",
-            r"https?://www\.nature\.com/[A-Za-z0-9_\-./]+",
-            r"https?://www\.biorxiv\.org/[A-Za-z0-9_\-./]+",
-            r"https?://www\.pnas\.org/[A-Za-z0-9_\-./]+",
-            r"https?://dl\.acm\.org/[A-Za-z0-9_\-./]+",
-            r"https?://ieeexplore\.ieee\.org/[A-Za-z0-9_\-./]+",
-            r"https?://www\.researchgate\.net/[A-Za-z0-9_\-./]+",
         ]
-        
+
         cleaned = _first_valid_paper_match(url_patterns, readme)
         if cleaned:
             return f'=HYPERLINK("{cleaned}", "Yes")'

--- a/gh_repo_exporter.py
+++ b/gh_repo_exporter.py
@@ -331,43 +331,63 @@ _KNOWN_PAPER_HOST_PATTERN = (
     rf"https?://(?:{_PAPER_HOST_DOMAIN_CODES})/[A-Za-z0-9_\-./]+"
 )
 
-def _first_valid_paper_match(patterns: list[str], text: str) -> str | None:
+# Publisher labels considered preprints rather than final publications.
+PREPRINT_LABELS = {"arXiv", "bioRxiv / Cold Spring Harbor"}
+
+def _is_preprint_doi(url: str) -> bool:
     """
-    Searches text for the first URL matching any pattern in its priority
-    order. Patterns are constructed to only match known-good sources, so
-    any match found is valid by construction.
-    
-    Returns the cleaned URL string if found, otherwise None.
+    Return True if url is a DOI link whose registrant prefix maps to a
+    preprint publisher (arXiv, bioRxiv).
     """
-    for pattern in patterns:
-        match = re.search(pattern, text, re.IGNORECASE)
-        if match:
-            return match.group(0).rstrip(").],};:>\"'")
-    return None
+    match = re.search(r"doi\.org/10\.(\d+)/", url, re.IGNORECASE)
+    if not match:
+        return False
+    return DOI_REGISTRANT_PREFIXES.get(match.group(1)) in PREPRINT_LABELS
+
+def _is_preprint_host(url: str) -> bool:
+    """
+    Return True if url's domain maps to a preprint publisher (arXiv, bioRxiv).
+    """
+    url_lower = url.lower()
+    for domain, label in PAPER_HOST_DOMAINS.items():
+        if domain in url_lower:
+            return label in PREPRINT_LABELS
+    return False
+
+def _find_paper_matches(text: str) -> list[tuple[int, bool, bool, str]]:
+    """
+    Find every known-publisher DOI and direct-host paper link in text.
+
+    Returns a list of (position, is_doi, is_preprint, cleaned_url) tuples
+    so get_associated_paper can rank matches by publication status, DOI
+    preference, and position in the text.
+    """
+    matches = []
+    for pattern, is_doi in [(_KNOWN_PUBLISHER_DOI_PATTERN, True),
+                             (_KNOWN_PAPER_HOST_PATTERN, False)]:
+        for m in re.finditer(pattern, text, re.IGNORECASE):
+            url = m.group(0).rstrip(").],};:>\"'")
+            is_preprint = _is_preprint_doi(url) if is_doi else _is_preprint_host(url)
+            matches.append((m.start(), is_doi, is_preprint, url))
+    return matches
 
 def get_associated_paper(readme: str, homepage: str | None = None) -> str:
     """
     Checks the README and then homepage as fallback for a link to an
-    associated paper.
-    
+    associated paper, matched against known publisher DOI and direct
+    URL patterns. Publications are preferred over preprints, DOI links
+    are preferred over direct URLs, and ties are broken by whichever
+    link appears first in the text.
+
     Returns an =HYPERLINK(...) formula pointing to the paper if found,
     otherwise "No".
     """
     try:
-        url_patterns = [
-            _KNOWN_PAPER_HOST_PATTERN,
-            _KNOWN_PUBLISHER_DOI_PATTERN,
-        ]
-
-        cleaned = _first_valid_paper_match(url_patterns, readme)
-        if cleaned:
-            return f'=HYPERLINK("{cleaned}", "Yes")'
-        
-        if homepage:
-            cleaned = _first_valid_paper_match(url_patterns, homepage)
-            if cleaned:
-                return f'=HYPERLINK("{cleaned}", "Yes")'
-
+        for text in (readme, homepage or ""):
+            matches = _find_paper_matches(text)
+            if matches:
+                best = min(matches, key=lambda m: (m[2], not m[1], m[0]))
+                return f'=HYPERLINK("{best[3]}", "Yes")'
         return "No"
     except Exception:
         return "No"

--- a/gh_repo_exporter.py
+++ b/gh_repo_exporter.py
@@ -313,11 +313,17 @@ _KNOWN_PUBLISHER_DOI_PATTERN = (
 # Direct (non-DOI) URL patterns for known paper-hosting publishers.
 PAPER_HOST_DOMAINS = {
     "arxiv.org": "arXiv",
-    "link.springer.com": "Springer",
-    "www.nature.com": "Nature",
-    "dl.acm.org": "ACM",
     "ieeexplore.ieee.org": "IEEE",
+    "onlinelibrary.wiley.com": "Wiley",
+    "www.pnas.org": "PNAS",
+    "www.science.org": "Science / AAAS",
+    "peerj.com": "PeerJ",
+    "www.nature.com": "Nature",
+    "link.springer.com": "Springer",
+    "dl.acm.org": "ACM",
+    "www.biorxiv.org": "bioRxiv / Cold Spring Harbor",
     "www.researchgate.net": "ResearchGate",
+    "www.tandfonline.com": "Taylor & Francis",
 }
 
 _PAPER_HOST_DOMAIN_CODES = "|".join(re.escape(d) for d in PAPER_HOST_DOMAINS)

--- a/gh_repo_exporter.py
+++ b/gh_repo_exporter.py
@@ -304,6 +304,16 @@ DOI_REGISTRANT_PREFIXES = {
     "1101": "bioRxiv / Cold Spring Harbor",
 }
 
+# Direct (non-DOI) URL patterns for known paper-hosting publishers.
+PAPER_HOST_URL_PATTERNS = {
+    r"https?://arxiv\.org/[A-Za-z0-9_\-./]+": "arXiv",
+    r"https?://link\.springer\.com/[A-Za-z0-9_\-./]+": "Springer",
+    r"https?://www\.nature\.com/[A-Za-z0-9_\-./]+": "Nature",
+    r"https?://dl\.acm\.org/[A-Za-z0-9_\-./]+": "ACM",
+    r"https?://ieeexplore\.ieee\.org/[A-Za-z0-9_\-./]+": "IEEE",
+    r"https?://www\.researchgate\.net/[A-Za-z0-9_\-./]+": "ResearchGate",
+}
+
 _DOI_PUB_CODES = "|".join(DOI_REGISTRANT_PREFIXES)
 _KNOWN_PUBLISHER_DOI_PATTERN = (
     rf"https?://doi\.org/10\.(?:{_DOI_PUB_CODES})/[A-Za-z0-9\-./]+"
@@ -333,15 +343,10 @@ def get_associated_paper(readme: str, homepage: str | None = None) -> str:
     """
     try:
         url_patterns = [
-            r"https?://arxiv\.org/[A-Za-z0-9_\-./]+",
+            *PAPER_HOST_URL_PATTERNS,
             _KNOWN_PUBLISHER_DOI_PATTERN,
-            r"https?://link\.springer\.com/[A-Za-z0-9_\-./]+",
-            r"https?://www\.nature\.com/[A-Za-z0-9_\-./]+",
-            r"https?://dl\.acm\.org/[A-Za-z0-9_\-./]+",
-            r"https?://ieeexplore\.ieee\.org/[A-Za-z0-9_\-./]+",
-            r"https?://www\.researchgate\.net/[A-Za-z0-9_\-./]+",
         ]
-
+        
         cleaned = _first_valid_paper_match(url_patterns, readme)
         if cleaned:
             return f'=HYPERLINK("{cleaned}", "Yes")'

--- a/gh_repo_exporter.py
+++ b/gh_repo_exporter.py
@@ -305,19 +305,24 @@ DOI_REGISTRANT_PREFIXES = {
     "1080": "Taylor & Francis",
 }
 
-# Direct (non-DOI) URL patterns for known paper-hosting publishers.
-PAPER_HOST_URL_PATTERNS = {
-    r"https?://arxiv\.org/[A-Za-z0-9_\-./]+": "arXiv",
-    r"https?://link\.springer\.com/[A-Za-z0-9_\-./]+": "Springer",
-    r"https?://www\.nature\.com/[A-Za-z0-9_\-./]+": "Nature",
-    r"https?://dl\.acm\.org/[A-Za-z0-9_\-./]+": "ACM",
-    r"https?://ieeexplore\.ieee\.org/[A-Za-z0-9_\-./]+": "IEEE",
-    r"https?://www\.researchgate\.net/[A-Za-z0-9_\-./]+": "ResearchGate",
-}
-
 _DOI_PUB_CODES = "|".join(DOI_REGISTRANT_PREFIXES)
 _KNOWN_PUBLISHER_DOI_PATTERN = (
     rf"https?://doi\.org/10\.(?:{_DOI_PUB_CODES})/[A-Za-z0-9\-./]+"
+)
+
+# Direct (non-DOI) URL patterns for known paper-hosting publishers.
+PAPER_HOST_DOMAINS = {
+    "arxiv.org": "arXiv",
+    "link.springer.com": "Springer",
+    "www.nature.com": "Nature",
+    "dl.acm.org": "ACM",
+    "ieeexplore.ieee.org": "IEEE",
+    "www.researchgate.net": "ResearchGate",
+}
+
+_PAPER_HOST_DOMAIN_CODES = "|".join(re.escape(d) for d in PAPER_HOST_DOMAINS)
+_KNOWN_PAPER_HOST_PATTERN = (
+    rf"https?://(?:{_PAPER_HOST_DOMAIN_CODES})/[A-Za-z0-9_\-./]+"
 )
 
 def _first_valid_paper_match(patterns: list[str], text: str) -> str | None:
@@ -344,7 +349,7 @@ def get_associated_paper(readme: str, homepage: str | None = None) -> str:
     """
     try:
         url_patterns = [
-            *PAPER_HOST_URL_PATTERNS,
+            _KNOWN_PAPER_HOST_PATTERN,
             _KNOWN_PUBLISHER_DOI_PATTERN,
         ]
 

--- a/gh_repo_exporter.py
+++ b/gh_repo_exporter.py
@@ -328,7 +328,7 @@ PAPER_HOST_DOMAINS = {
 
 _PAPER_HOST_DOMAIN_CODES = "|".join(re.escape(d) for d in PAPER_HOST_DOMAINS)
 _KNOWN_PAPER_HOST_PATTERN = (
-    rf"https?://(?:{_PAPER_HOST_DOMAIN_CODES})/[A-Za-z0-9_\-./]+"
+    rf"https?://(?:[A-Za-z0-9-]+\.)*(?:{_PAPER_HOST_DOMAIN_CODES})/[A-Za-z0-9_\-./]+"
 )
 
 # Publisher labels considered preprints rather than final publications.


### PR DESCRIPTION
#50 
#31 

`get_associated_paper` before was marking repos as having no associated paper even when there was a valid arxiv/doi/etc. link present in the README. This is because it required the markdown link text to be exactly "paper" or "arxiv", so common cases like badges, bare URLs, and links with other labels were not considered. 

This now matches paper URLs by domain (arxiv, doi, springer, nature, acm, ieee, researchgate) anywhere in `README.md` regardless of surrounding markdown formatting before falling back to the repo's homepage field.
