### PR TITLE
refactor/ transfer paper function prioritization implementation from legacy to package 

### DIFF
--- a/src/repo_exporter/github.py
+++ b/src/repo_exporter/github.py
@@ -54,7 +54,7 @@ PAPER_HOST_DOMAINS = {
 
 _PAPER_HOST_DOMAIN_CODES = "|".join(re.escape(d) for d in PAPER_HOST_DOMAINS)
 _KNOWN_PAPER_HOST_PATTERN = (
-    rf"https?://(?:{_PAPER_HOST_DOMAIN_CODES})/[A-Za-z0-9_\-./]+"
+    rf"https?://(?:[A-Za-z0-9-]+\.)*(?:{_PAPER_HOST_DOMAIN_CODES})/[A-Za-z0-9_\-./]+"
 )
 
 class GitHubExporter(BaseExporter):

--- a/src/repo_exporter/github.py
+++ b/src/repo_exporter/github.py
@@ -16,6 +16,47 @@ PACKAGE_REQUIREMENT_FILES = [
     "package.json", "package-lock.json", "yarn.lock", "bower.json",
 ]
 
+# DOI registrant prefixes for known paper-hosting publishers.
+DOI_REGISTRANT_PREFIXES = {
+    "48550": "arXiv",
+    "1109": "IEEE",
+    "1111": "Wiley",
+    "1073": "PNAS",
+    "1126": "Science / AAAS",
+    "7717": "PeerJ",
+    "1038": "Nature",
+    "1007": "Springer",
+    "1145": "ACM",
+    "1101": "bioRxiv / Cold Spring Harbor",
+    "1080": "Taylor & Francis",
+}
+
+_DOI_PUB_CODES = "|".join(DOI_REGISTRANT_PREFIXES)
+_KNOWN_PUBLISHER_DOI_PATTERN = (
+    rf"https?://doi\.org/10\.(?:{_DOI_PUB_CODES})/[A-Za-z0-9\-./]+"
+)
+
+# Direct (non-DOI) URL patterns for known paper-hosting publishers.
+PAPER_HOST_DOMAINS = {
+    "arxiv.org": "arXiv",
+    "ieeexplore.ieee.org": "IEEE",
+    "onlinelibrary.wiley.com": "Wiley",
+    "www.pnas.org": "PNAS",
+    "www.science.org": "Science / AAAS",
+    "peerj.com": "PeerJ",
+    "www.nature.com": "Nature",
+    "link.springer.com": "Springer",
+    "dl.acm.org": "ACM",
+    "www.biorxiv.org": "bioRxiv / Cold Spring Harbor",
+    "www.researchgate.net": "ResearchGate",
+    "www.tandfonline.com": "Taylor & Francis",
+}
+
+_PAPER_HOST_DOMAIN_CODES = "|".join(re.escape(d) for d in PAPER_HOST_DOMAINS)
+_KNOWN_PAPER_HOST_PATTERN = (
+    rf"https?://(?:{_PAPER_HOST_DOMAIN_CODES})/[A-Za-z0-9_\-./]+"
+)
+
 class GitHubExporter(BaseExporter):
     """
     Exports GitHub org repo metadata to a Google Sheet.
@@ -396,10 +437,29 @@ class GitHubExporter(BaseExporter):
         except Exception:
             return "No"
 
+    @staticmethod
+    def _first_valid_paper_match(patterns: list[str], text: str) -> str | None:
+        """
+        Search text for the first URL matching any pattern in priority order.
+        Patterns only match known-good sources, so any match found is valid
+        by construction.
+
+        Parameters:
+        ------------
+        patterns - List of regex pattern strings, checked in order.
+        text     - String to search.
+        """
+        for pattern in patterns:
+            match = re.search(pattern, text, re.IGNORECASE)
+            if match:
+                return match.group(0).rstrip(").],};:>\"'")
+        return None
+
     def get_associated_paper(self, readme: str, homepage: str | None = None) -> str:
         """
-        Search README for a markdown link labeled "paper" or "arxiv" pointing to
-        a known publisher URL. Falls back to homepage. Returns a HYPERLINK formula or "No".
+        Check the README and then homepage as fallback for a link to an
+        associated paper, matched against known publisher DOI and direct
+        URL patterns. Returns a HYPERLINK formula or "No".
 
         Parameters:
         ------------
@@ -408,29 +468,20 @@ class GitHubExporter(BaseExporter):
         """
         try:
             url_patterns = [
-                r"https?://arxiv\.org/[A-Za-z0-9_\-./]+",
-                r"https?://doi\.org/[A-Za-z0-9_\-./]+",
-                r"https?://link\.springer\.com/[A-Za-z0-9_\-./]+",
-                r"https?://www\.nature\.com/[A-Za-z0-9_\-./]+",
-                r"https?://dl\.acm\.org/[A-Za-z0-9_\-./]+",
-                r"https?://ieeexplore\.ieee\.org/[A-Za-z0-9_\-./]+",
-                r"https?://www\.researchgate\.net/[A-Za-z0-9_\-./]+",
+                _KNOWN_PAPER_HOST_PATTERN,
+                _KNOWN_PUBLISHER_DOI_PATTERN,
             ]
-            markdown_link_pattern = r"\[([^\]]+)\]\((.*?)\)"
 
-            for label, url in re.findall(markdown_link_pattern, readme):
-                if label.strip().lower() not in {"paper", "arxiv"}:
-                    continue
-                for pattern in url_patterns:
-                    if re.search(pattern, url, re.IGNORECASE):
-                        cleaned = url.rstrip(").],};:>\"'").replace('"', '""')
-                        return f'=HYPERLINK("{cleaned}", "Yes")'
+            cleaned = self._first_valid_paper_match(url_patterns, readme)
+            if cleaned:
+                cleaned = cleaned.replace('"', '""')
+                return f'=HYPERLINK("{cleaned}", "Yes")'
 
             if homepage:
-                for pattern in url_patterns:
-                    if re.search(pattern, homepage, re.IGNORECASE):
-                        cleaned = homepage.rstrip(").],};:>\"'").replace('"', '""')
-                        return f'=HYPERLINK("{cleaned}", "Yes")'
+                cleaned = self._first_valid_paper_match(url_patterns, homepage)
+                if cleaned:
+                    cleaned = cleaned.replace('"', '""')
+                    return f'=HYPERLINK("{cleaned}", "Yes")'
 
             return "No"
         except Exception:

--- a/src/repo_exporter/github.py
+++ b/src/repo_exporter/github.py
@@ -437,30 +437,69 @@ class GitHubExporter(BaseExporter):
         except Exception:
             return "No"
 
+    # Publisher labels considered preprints rather than final publications.
+    PREPRINT_LABELS = {"arXiv", "bioRxiv / Cold Spring Harbor"}
+
     @staticmethod
-    def _first_valid_paper_match(patterns: list[str], text: str) -> str | None:
+    def _is_preprint_doi(url: str) -> bool:
         """
-        Search text for the first URL matching any pattern in priority order.
-        Patterns only constructed to only match known-good sources, so any match found is valid by construction.
-        
-        Returns a cleaned URL string if match found, otherwise None.
+        Return True if url is a DOI link whose registrant prefix maps to a
+        preprint publisher (arXiv, bioRxiv).
 
         Parameters:
         ------------
-        patterns - List of regex pattern strings, checked in order.
-        text     - String to search.
+        url - String. A doi.org URL.
         """
-        for pattern in patterns:
-            match = re.search(pattern, text, re.IGNORECASE)
-            if match:
-                return match.group(0).rstrip(").],};:>\"'")
-        return None
+        match = re.search(r"doi\.org/10\.(\d+)/", url, re.IGNORECASE)
+        if not match:
+            return False
+        return DOI_REGISTRANT_PREFIXES.get(match.group(1)) in GitHubExporter.PREPRINT_LABELS
+
+    @staticmethod
+    def _is_preprint_host(url: str) -> bool:
+        """
+        Return True if url's domain maps to a preprint publisher (arXiv, bioRxiv).
+
+        Parameters:
+        ------------
+        url - String. A direct paper-host URL.
+        """
+        url_lower = url.lower()
+        for domain, label in PAPER_HOST_DOMAINS.items():
+            if domain in url_lower:
+                return label in GitHubExporter.PREPRINT_LABELS
+        return False
+
+    def _find_paper_matches(self, text: str) -> list[tuple[int, bool, bool, str]]:
+        """
+        Find every known-publisher DOI and direct-host paper link in text.
+
+        Returns a list of (position, is_doi, is_preprint, cleaned_url) tuples
+        so get_associated_paper can rank matches by publication status, DOI
+        preference, and position in the text.
+
+        Parameters:
+        ------------
+        text - String to search.
+        """
+        matches = []
+        for pattern, is_doi in [(_KNOWN_PUBLISHER_DOI_PATTERN, True),
+                                 (_KNOWN_PAPER_HOST_PATTERN, False)]:
+            for m in re.finditer(pattern, text, re.IGNORECASE):
+                url = m.group(0).rstrip(").],};:>\"'")
+                is_preprint = self._is_preprint_doi(url) if is_doi else self._is_preprint_host(url)
+                matches.append((m.start(), is_doi, is_preprint, url))
+        return matches
 
     def get_associated_paper(self, readme: str, homepage: str | None = None) -> str:
         """
         Check the README and then homepage as fallback for a link to an
         associated paper, matched against known publisher DOI and direct
-        URL patterns. Returns a HYPERLINK formula pointing to the paper if found, or "No".
+        URL patterns. Publications are preferred over preprints, DOI links
+        are preferred over direct URLs, and ties are broken by whichever
+        link appears first in the text. 
+        
+        Returns a HYPERLINK formula pointing to the paper if found, or "No".
 
         Parameters:
         ------------
@@ -468,20 +507,11 @@ class GitHubExporter(BaseExporter):
         homepage - String | None. Repo homepage URL as a fallback.
         """
         try:
-            url_patterns = [
-                _KNOWN_PAPER_HOST_PATTERN,
-                _KNOWN_PUBLISHER_DOI_PATTERN,
-            ]
-
-            cleaned = self._first_valid_paper_match(url_patterns, readme)
-            if cleaned:
-                return f'=HYPERLINK("{cleaned}", "Yes")'
-
-            if homepage:
-                cleaned = self._first_valid_paper_match(url_patterns, homepage)
-                if cleaned:
-                    return f'=HYPERLINK("{cleaned}", "Yes")'
-
+            for text in (readme, homepage or ""):
+                matches = self._find_paper_matches(text)
+                if matches:
+                    best = min(matches, key=lambda m: (m[2], not m[1], m[0]))
+                    return f'=HYPERLINK("{best[3]}", "Yes")'
             return "No"
         except Exception:
             return "No"

--- a/src/repo_exporter/github.py
+++ b/src/repo_exporter/github.py
@@ -475,13 +475,11 @@ class GitHubExporter(BaseExporter):
 
             cleaned = self._first_valid_paper_match(url_patterns, readme)
             if cleaned:
-                cleaned = cleaned.replace('"', '""')
                 return f'=HYPERLINK("{cleaned}", "Yes")'
 
             if homepage:
                 cleaned = self._first_valid_paper_match(url_patterns, homepage)
                 if cleaned:
-                    cleaned = cleaned.replace('"', '""')
                     return f'=HYPERLINK("{cleaned}", "Yes")'
 
             return "No"

--- a/src/repo_exporter/github.py
+++ b/src/repo_exporter/github.py
@@ -441,8 +441,9 @@ class GitHubExporter(BaseExporter):
     def _first_valid_paper_match(patterns: list[str], text: str) -> str | None:
         """
         Search text for the first URL matching any pattern in priority order.
-        Patterns only match known-good sources, so any match found is valid
-        by construction.
+        Patterns only constructed to only match known-good sources, so any match found is valid by construction.
+        
+        Returns a cleaned URL string if match found, otherwise None.
 
         Parameters:
         ------------
@@ -459,7 +460,7 @@ class GitHubExporter(BaseExporter):
         """
         Check the README and then homepage as fallback for a link to an
         associated paper, matched against known publisher DOI and direct
-        URL patterns. Returns a HYPERLINK formula or "No".
+        URL patterns. Returns a HYPERLINK formula pointing to the paper if found, or "No".
 
         Parameters:
         ------------

--- a/tests/repo_exporter/test_github.py
+++ b/tests/repo_exporter/test_github.py
@@ -174,7 +174,7 @@ title: Cool Project
 doi: 10.5281/zenodo.1234567
 """
 
-# get_repo_info golden tests
+# get_repo_info() golden tests
 
 def test_get_repo_info_matches_expected_output():
     """Golden test: a fully-populated repo should produce this exact row."""
@@ -322,7 +322,7 @@ def test_get_repo_info_forked_and_archived_repo():
     assert result["DOI for GitHub Repo"] == "No"
 
 
-# get_repo_creator (cache hit / fallback paths)
+# get_repo_creator() (cache hit / fallback paths)
 
 def _make_repo_for_creator(name: str, created_at_str: str) -> MagicMock:
     repo = MagicMock()
@@ -469,7 +469,7 @@ def test_get_repo_creator_correct_last_page_index_is_requested():
     commits.get_page.assert_called_once_with(expected_page)
 
 
-# is_valid_doi / has_doi
+# is_valid_doi() / has_doi()
 
 def test_is_valid_doi_accepts_zenodo_doi():
     exporter = make_exporter()
@@ -564,3 +564,97 @@ def test_has_doi_no_citation_and_no_badge_returns_no():
     repo = MagicMock()
     repo.get_contents.side_effect = GithubException(404, "Not Found", None)
     assert exporter.has_doi(repo, "no badge here") == "No"
+
+# _first_valid_paper_match()
+
+def test_first_valid_paper_match_returns_first_matching_pattern():
+    patterns = [r"https?://foo\.com/\S+", r"https?://bar\.com/\S+"]
+    text = "check out https://bar.com/page1"
+    result = GitHubExporter._first_valid_paper_match(patterns, text)
+    assert result == "https://bar.com/page1"
+
+
+def test_first_valid_paper_match_respects_pattern_priority_order():
+    """If multiple patterns could match, the earlier pattern in the list wins,
+    even if its match appears later in the text."""
+    patterns = [r"https?://bar\.com/\S+", r"https?://foo\.com/\S+"]
+    text = "https://foo.com/first then https://bar.com/second"
+    result = GitHubExporter._first_valid_paper_match(patterns, text)
+    assert result == "https://bar.com/second"
+
+
+def test_first_valid_paper_match_strips_trailing_punctuation():
+    patterns = [r"https?://foo\.com/\S+"]
+    text = "(see https://foo.com/page)."
+    result = GitHubExporter._first_valid_paper_match(patterns, text)
+    assert result == "https://foo.com/page"
+
+
+def test_first_valid_paper_match_returns_none_when_no_pattern_matches():
+    patterns = [r"https?://foo\.com/\S+"]
+    text = "nothing relevant here"
+    assert GitHubExporter._first_valid_paper_match(patterns, text) is None
+
+# get_associated_paper()
+
+def test_get_associated_paper_matches_known_doi_prefix():
+    """A doi.org link with a recognized registrant prefix (Springer) should match."""
+    exporter = make_exporter()
+    readme = "See https://doi.org/10.1007/s00442-020-04756-5 for details."
+    result = exporter.get_associated_paper(readme)
+    assert result == '=HYPERLINK("https://doi.org/10.1007/s00442-020-04756-5", "Yes")'
+
+
+def test_get_associated_paper_rejects_unknown_doi_prefix():
+    """A doi.org link whose registrant prefix isn't in DOI_REGISTRANT_PREFIXES
+    should not be treated as a paper link."""
+    exporter = make_exporter()
+    readme = "See https://doi.org/10.9999/unknownjournal.123 for details."
+    assert exporter.get_associated_paper(readme) == "No"
+
+
+def test_get_associated_paper_matches_direct_publisher_domain():
+    """A direct (non-DOI) link to a known paper host, e.g. bioRxiv, should match
+    even without any doi.org URL present."""
+    exporter = make_exporter()
+    readme = "Preprint: https://www.biorxiv.org/content/10.1101/2020.01.01.123456v1"
+    result = exporter.get_associated_paper(readme)
+    assert result == '=HYPERLINK("https://www.biorxiv.org/content/10.1101/2020.01.01.123456v1", "Yes")'
+
+
+def test_get_associated_paper_homepage_fallback_matches_doi_prefix():
+    """The homepage fallback should also be checked against the known DOI
+    registrant prefixes, not just direct publisher domains."""
+    exporter = make_exporter()
+    result = exporter.get_associated_paper(
+        "nothing relevant here", homepage="https://doi.org/10.1038/s41586-020-1234-5"
+    )
+    assert result == '=HYPERLINK("https://doi.org/10.1038/s41586-020-1234-5", "Yes")'
+
+
+def test_get_associated_paper_direct_domain_takes_priority_over_doi_link():
+    """When both a doi.org link and a direct known-host link are present,
+    the direct-host match wins, since it's checked first regardless of
+    which URL appears earlier in the text."""
+    exporter = make_exporter()
+    readme = (
+        "First https://doi.org/10.1007/s00442-020-04756-5 "
+        "then https://www.nature.com/articles/s41586"
+    )
+    result = exporter.get_associated_paper(readme)
+    assert result == '=HYPERLINK("https://www.nature.com/articles/s41586", "Yes")'
+
+
+def test_get_associated_paper_strips_trailing_punctuation():
+    """A URL followed by closing punctuation (parens, periods, etc.) should
+    have that punctuation stripped from the matched link."""
+    exporter = make_exporter()
+    result = exporter.get_associated_paper("(see https://arxiv.org/abs/2301.01234).")
+    assert result == '=HYPERLINK("https://arxiv.org/abs/2301.01234", "Yes")'
+
+
+def test_get_associated_paper_no_match_in_readme_or_homepage_returns_no():
+    """No known-publisher link anywhere should return 'No'."""
+    exporter = make_exporter()
+    result = exporter.get_associated_paper("nothing relevant", homepage="https://example.com")
+    assert result == "No"

--- a/tests/repo_exporter/test_github.py
+++ b/tests/repo_exporter/test_github.py
@@ -565,37 +565,43 @@ def test_has_doi_no_citation_and_no_badge_returns_no():
     repo.get_contents.side_effect = GithubException(404, "Not Found", None)
     assert exporter.has_doi(repo, "no badge here") == "No"
 
-# _first_valid_paper_match()
+# _find_paper_matches()
 
-def test_first_valid_paper_match_returns_first_matching_pattern():
-    patterns = [r"https?://foo\.com/\S+", r"https?://bar\.com/\S+"]
-    text = "check out https://bar.com/page1"
-    result = GitHubExporter._first_valid_paper_match(patterns, text)
-    assert result == "https://bar.com/page1"
-
-
-def test_first_valid_paper_match_respects_pattern_priority_order():
-    """If multiple patterns could match, the earlier pattern in the list wins,
-    even if its match appears later in the text."""
-    patterns = [r"https?://bar\.com/\S+", r"https?://foo\.com/\S+"]
-    text = "https://foo.com/first then https://bar.com/second"
-    result = GitHubExporter._first_valid_paper_match(patterns, text)
-    assert result == "https://bar.com/second"
+def test_find_paper_matches_finds_direct_and_doi_matches():
+    exporter = make_exporter()
+    text = "https://arxiv.org/abs/1234 and https://doi.org/10.1038/s41586-020-1234-5"
+    matches = exporter._find_paper_matches(text)
+    urls = {m[3] for m in matches}
+    assert urls == {
+        "https://arxiv.org/abs/1234",
+        "https://doi.org/10.1038/s41586-020-1234-5",
+    }
 
 
-def test_first_valid_paper_match_strips_trailing_punctuation():
-    patterns = [r"https?://foo\.com/\S+"]
-    text = "(see https://foo.com/page)."
-    result = GitHubExporter._first_valid_paper_match(patterns, text)
-    assert result == "https://foo.com/page"
+def test_find_paper_matches_flags_preprints():
+    exporter = make_exporter()
+    matches = exporter._find_paper_matches("https://arxiv.org/abs/1234")
+    assert matches[0][2] is True  # is_preprint
 
 
-def test_first_valid_paper_match_returns_none_when_no_pattern_matches():
-    patterns = [r"https?://foo\.com/\S+"]
-    text = "nothing relevant here"
-    assert GitHubExporter._first_valid_paper_match(patterns, text) is None
+def test_find_paper_matches_flags_publications():
+    exporter = make_exporter()
+    matches = exporter._find_paper_matches("https://www.nature.com/articles/s41586")
+    assert matches[0][2] is False  # is_preprint
 
-# get_associated_paper()
+
+def test_find_paper_matches_strips_trailing_punctuation():
+    exporter = make_exporter()
+    matches = exporter._find_paper_matches("(see https://arxiv.org/abs/1234).")
+    assert matches[0][3] == "https://arxiv.org/abs/1234"
+
+
+def test_find_paper_matches_returns_empty_list_when_no_match():
+    exporter = make_exporter()
+    assert exporter._find_paper_matches("nothing relevant here") == []
+    
+# get_associated_paper() priority rules 
+
 
 def test_get_associated_paper_matches_known_doi_prefix():
     """A doi.org link with a recognized registrant prefix (Springer) should match."""
@@ -631,20 +637,6 @@ def test_get_associated_paper_homepage_fallback_matches_doi_prefix():
     )
     assert result == '=HYPERLINK("https://doi.org/10.1038/s41586-020-1234-5", "Yes")'
 
-
-def test_get_associated_paper_direct_domain_takes_priority_over_doi_link():
-    """When both a doi.org link and a direct known-host link are present,
-    the direct-host match wins, since it's checked first regardless of
-    which URL appears earlier in the text."""
-    exporter = make_exporter()
-    readme = (
-        "First https://doi.org/10.1007/s00442-020-04756-5 "
-        "then https://www.nature.com/articles/s41586"
-    )
-    result = exporter.get_associated_paper(readme)
-    assert result == '=HYPERLINK("https://www.nature.com/articles/s41586", "Yes")'
-
-
 def test_get_associated_paper_strips_trailing_punctuation():
     """A URL followed by closing punctuation (parens, periods, etc.) should
     have that punctuation stripped from the matched link."""
@@ -658,3 +650,39 @@ def test_get_associated_paper_no_match_in_readme_or_homepage_returns_no():
     exporter = make_exporter()
     result = exporter.get_associated_paper("nothing relevant", homepage="https://example.com")
     assert result == "No"
+    
+def test_get_associated_paper_doi_takes_priority_over_direct_domain():
+    """When both a doi.org link and a direct known-host link are present
+    and neither is a preprint, the DOI link wins, regardless of which
+    URL appears earlier in the text."""
+    exporter = make_exporter()
+    readme = (
+        "First https://doi.org/10.1007/s00442-020-04756-5 "
+        "then https://www.nature.com/articles/s41586"
+    )
+    result = exporter.get_associated_paper(readme)
+    assert result == '=HYPERLINK("https://doi.org/10.1007/s00442-020-04756-5", "Yes")'
+
+
+def test_get_associated_paper_publication_takes_priority_over_preprint():
+    """A known-publisher (non-preprint) link wins over a preprint link,
+    even if the preprint link is a DOI and appears earlier in the text."""
+    exporter = make_exporter()
+    readme = (
+        "Preprint: https://doi.org/10.48550/arXiv.1234.5678 "
+        "Published: https://www.nature.com/articles/s41586"
+    )
+    result = exporter.get_associated_paper(readme)
+    assert result == '=HYPERLINK("https://www.nature.com/articles/s41586", "Yes")'
+
+
+def test_get_associated_paper_breaks_ties_by_position():
+    """When two matches have the same preprint status and DOI-vs-URL type,
+    the one appearing first in the text wins."""
+    exporter = make_exporter()
+    readme = (
+        "https://doi.org/10.1038/s41586-020-1234-5 "
+        "https://doi.org/10.1007/s00442-020-04756-5"
+    )
+    result = exporter.get_associated_paper(readme)
+    assert result == '=HYPERLINK("https://doi.org/10.1038/s41586-020-1234-5", "Yes")'

--- a/tests/repo_exporter/test_github.py
+++ b/tests/repo_exporter/test_github.py
@@ -675,7 +675,16 @@ def test_get_associated_paper_publication_takes_priority_over_preprint():
     result = exporter.get_associated_paper(readme)
     assert result == '=HYPERLINK("https://www.nature.com/articles/s41586", "Yes")'
 
-
+def test_get_associated_paper_matches_subdomained_publisher_host():
+    """
+    Wiley journal links live on subdomains 
+    (e.g. besjournals.onlinelibrary.wiley.com, the wildwing paper URL). 
+    The host pattern should match them, not just the bare domain.
+    """
+    exporter = make_exporter()
+    readme = "Paper: https://besjournals.onlinelibrary.wiley.com/doi/10.1111/2041-210X.70018"
+    result = exporter.get_associated_paper(readme)
+    assert result == '=HYPERLINK("https://besjournals.onlinelibrary.wiley.com/doi/10.1111/2041-210X.70018", "Yes")'
 def test_get_associated_paper_breaks_ties_by_position():
     """When two matches have the same preprint status and DOI-vs-URL type,
     the one appearing first in the text wins."""


### PR DESCRIPTION
Transferred implementation of DOI registrant prefixes & known publisher domain URL links, `_first_valid_paper_match()`, and `get_associated_paper()` from the legacy script, `gh_repo_exporter.py` to the package. Also have added unit tests for the new implementation. 
